### PR TITLE
[WIP] Load states

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -21,5 +21,8 @@
 @import 'styleguide';
 @import 'typography';
 
+// general-purpose classes
+@import 'loadable';
+
 // Web Components
 @import 'components/components';

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -10,6 +10,7 @@
 // Mixins
 @import 'mixins/font-size';
 @import 'mixins/grid-settings';
+@import 'mixins/loadable-state-display';
 
 // Extends
 @import 'extends/buttons';

--- a/_sass/base/_loadable.scss
+++ b/_sass/base/_loadable.scss
@@ -1,18 +1,14 @@
 // loadable components may contain elements that should be shown or
 // hidden in specific states.
 .loadable {
-  @each $state in loading, loaded, error {
-    .show-#{$state} {
+  @each $state in $loadable-states {
+    .show-#{$state},
+    &.js-#{$state} .hide-#{$state} {
       display: none;
     }
 
-    &.js-#{$state} {
-      .show-#{$state} {
-        display: block;
-      }
-      .hide-#{$state} {
-        display: none;
-      }
+    &.js-#{$state} .show-#{$state} {
+      display: block;
     }
   }
 }

--- a/_sass/base/_loadable.scss
+++ b/_sass/base/_loadable.scss
@@ -1,0 +1,18 @@
+// loadable components may contain elements that should be shown or
+// hidden in specific states.
+.loadable {
+  @each $state in loading, loaded, error {
+    .show-#{$state} {
+      display: none;
+    }
+
+    &.js-#{$state} {
+      .show-#{$state} {
+        display: block;
+      }
+      .hide-#{$state} {
+        display: none;
+      }
+    }
+  }
+}

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -71,3 +71,7 @@ $form-box-shadow: none;
 $form-box-shadow-focus: 0 0 0 2px $mid-blue;
 $form-font-family: $base-font-family;
 $form-input-color: $dark-gray;
+
+// loadable states
+$loadable-states: (loading, loaded, error);
+

--- a/_sass/base/mixins/_loadable-state-display.scss
+++ b/_sass/base/mixins/_loadable-state-display.scss
@@ -1,0 +1,21 @@
+// override the display property for a loadable
+// state element:
+// 
+// .foo {
+//   @include loadable-state-display(inline-block);
+// }
+//
+// or optionally specify a list of states:
+// 
+// .foo {
+//   @include loadable-state-display(inline-block, (error,));
+// }
+// 
+@mixin loadable-state-display($display, $states:$loadable-states) {
+  @each $state in $states {
+    .loadable.js-#{$state} .show-#{$state} {
+      display: $display;
+    }
+  }
+}
+

--- a/js/search.js
+++ b/js/search.js
@@ -3,7 +3,7 @@
   var resultsRoot = document.querySelector('.search-results');
   var query = location.search;
   if (!query) {
-    resultsRoot.classList.add('js-empty');
+    resultsRoot.classList.add('hidden');
     return;
   }
 
@@ -59,10 +59,13 @@
 
   resultsRoot.classList.add('js-loading');
   API.search(values, function(error, rows) {
+    resultsRoot.classList.remove('hidden');
     resultsRoot.classList.remove('js-loading');
+
     if (error) {
       return showError(error);
     }
+
     console.log('loaded schools:', rows);
     resultsRoot.classList.add('js-loaded');
 
@@ -91,8 +94,8 @@
     console.time('[render] charts');
     // bind all of the data to elements in d3, then
     // call renderCharts() on the selection
-    d3.select(resultsRoot)
-      .selectAll('.school-item')
+    d3.select(resultsList)
+      .selectAll('.school')
       .data(rows)
       .call(renderCharts);
     console.timeEnd('[render] charts');
@@ -101,11 +104,13 @@
   });
 
   function renderCharts(selection) {
+    selection.select('.size')
+      .text(format.number('size'));
   }
 
   function showError(error) {
     console.error('error:', error);
-    resultsRoot.classList.add('error');
+    resultsRoot.classList.add('js-error');
     var out = resultsRoot.querySelector('.error');
     out.classList.remove('hidden');
     out.textContent = String(error);

--- a/search/index.html
+++ b/search/index.html
@@ -10,9 +10,16 @@ body_scripts:
 ---
 
 <!-- Search results -->
-<section class="results search-results">
+<section class="results search-results loadable">
+  <h1 class="show-loading">
+    Loading...
+  </h1>
 
-  <div class="container">
+  <div class="show-error">
+    <p class="error-message"></p>
+  </div>
+
+  <div class="container show-loaded">
     <h1>
       <span class="results-count" data-bind="count">0</span>
       <span data-bind="results">Results</span>
@@ -21,17 +28,13 @@ body_scripts:
     <a href="#search-form" class="link-more">&lt; Edit Criteria</a>
   </div>
 
-  <div class="error hidden">
-    <p class="error-message"></p>
-  </div>
-
-  <section class="tertiary">
+  <section class="tertiary show-loaded">
 
     <div class="schools-list container" data-bind="schools">
       <!-- this element is the template for the results listing -->
       <div class="school results-cards">
         <h1 class="name">School Name</h1>
-        <ul class="school-info">
+        <ul class="school-info" data-bind="info">
           <li class="location">
             <span data-bind="city">City</span>,
             <span data-bind="state">State</span>
@@ -41,11 +44,11 @@ body_scripts:
             <span data-bind="category">category here</span>
           </li>
           <li>
-            <span data-bind="size">x</span> undergraduate students
+            <span class="size">x</span> undergraduate students
           </li>
         </ul>
 
-        <a data-bind="link" class="link-more">
+        <a class="link link-more">
           View more details <i class="fa fa-chevron-right"></i>
         </a>
       </div>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -274,6 +274,7 @@ layout: default
   </section>
 
   <section id="accordion" class="guide-container">
+    <h1>Accordions</h1>
 
     <div class="picc-accordion">
       <h1>
@@ -296,6 +297,44 @@ layout: default
       <div id="pa2-content">
         <p>This <i>should</i> show up by default.</p>
       </div>
+    </div>
+
+  </section>
+
+  <section id="load-states" class="container">
+
+    <h1>Loadable State Classes</h1>
+
+    <div class="loadable">
+      <h2>No State</h2>
+      <p>There should be no text below this paragraph.</p>
+      <p class="show-error">This error should <u>not</u> be visible.</p>
+      <p class="show-loading">This loading message should <u>not</u> be visible.</p>
+      <p class="show-loaded">This loaded message should <u>not</u> be visible.</p>
+    </div>
+
+    <div class="loadable js-loading">
+      <h2>Loading State</h2>
+      <p class="show-error">This error should <u>not</u> be visible.</p>
+      <p class="show-loading">This loading message <u>should</u> be visible.</p>
+      <p class="show-loaded">This loaded message should <u>not</u> be visible.</p>
+      <p class="hide-loading">This hidden loading message should <u>not</u> be visible.</p>
+    </div>
+
+    <div class="loadable js-loaded">
+      <h2>Loaded State</h2>
+      <p class="show-error">This error should <u>not</u> be visible.</p>
+      <p class="show-loading">This loading message should <u>not</u> be visible.</p>
+      <p class="show-loaded">This loaded message <u>should</u> be visible.</p>
+      <p class="hide-loaded">This hidden loaded message should <u>not</u> be visible.</p>
+    </div>
+
+    <div class="loadable js-error">
+      <h2>Error State</h2>
+      <p class="show-error">This error <u>should</u> be visible.</p>
+      <p class="show-loading">This loading message should <u>not</u> be visible.</p>
+      <p class="show-loaded">This loaded message should <u>not</u> be visible.</p>
+      <p class="hide-error">This hidden error message should <u>not</u> be visible.</p>
     </div>
 
   </section>


### PR DESCRIPTION
This PR introduces some utility classes for specifying the visibility of various elements in the scope of "loadable" elements. For instance:

```html
<div class="loadable">
  <p class="show-error error-message">This is an error message, hidden by default.</p>
  <p class="show-loading">Loading...</p>
  <p class="show-loaded">Loaded!</p>
</div>
```

The `show-{state}` and `hide-{state}` classes are "activated" by toggling corresponding classes on the `loadable` parent in JavaScript, using the `js-{state}` classes:

```js
var loadable = d3.select('.loadable')
  .classed('js-loading', true);
d3.json('data.json', function(error, data) {
  loadable.classed('js-loading', false);
  if (error) {
    return loadable.classed('js-error', true)
      .select('.error-message')
        .text(error);
  }
  loadable.classed('js-loaded', true);
});
```

This gives us a standard way to show and hide loading, error and loaded messages (or content) just by toggling flags on the parent element.

The only thing I'm not 100% stoked on here is that the `.show-{state}` rule sets `display: block`. @meiqimichelle, what do you think?