### PR TITLE
Omit trailing slash from basurl for consistency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title: College Choice
 description:
   Write an awesome description for your new site here.
 
-baseurl: "/college-choice/" # the subpath of your site, e.g. /blog/
+baseurl: "/college-choice" # the subpath of your site, e.g. /blog
 
 # Build settings
 markdown: kramdown
@@ -12,7 +12,7 @@ markdown: kramdown
 sass:
   style: nested
 
-# common site scripts, relative to `{{ site.baseurl }}js/`
+# common site scripts, relative to `{{ site.baseurl }}/js/`
 scripts:
   - vendor/aight.min.js
   - vendor/d3.min.js

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,11 +12,11 @@
 
   <!-- site scripts -->
   {% for script in site.scripts %}
-  <script src="{{ site.baseurl }}js/{{ script }}"></script>
+  <script src="{{ site.baseurl }}/js/{{ script }}"></script>
   {% endfor %}
 
   {% if page.scripts %}<!-- page scripts -->
   {% for script in page.scripts %}
-  <script src="{{ site.baseurl }}js/{{ script }}"></script>
+  <script src="{{ site.baseurl }}/js/{{ script }}"></script>
   {% endfor %}{% endif %}
 </head>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -1,4 +1,4 @@
-<form id="search-form" is="search-form" action="{{ site.baseurl }}search/" method="GET">
+<form id="search-form" is="search-form" action="{{ site.baseurl }}/search/" method="GET">
   {% capture common_input_attributes %}autocomplete="off" autocorrect="off" autocapitalize="off"{% endcapture %}
 
   <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     {% include footer.html %}
 
     {% for script in page.body_scripts %}
-    <script src="{{ site.baseurl }}js/{{ script }}" data-src="{{ script }}"></script>
+    <script src="{{ site.baseurl }}/js/{{ script }}" data-src="{{ script }}"></script>
     {% endfor %}
   </body>
 </html>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -116,7 +116,7 @@ layout: default
 
     <h1 class="search_category">Forms</h1>
 
-    <form is="search-form" action="{{ site.baseurl }}search/" method="GET">
+    <form is="search-form" action="{{ site.baseurl }}/search/" method="GET">
     {% capture common_input_attributes %}autocomplete="off" autocorrect="off" autocapitalize="off"{% endcapture %}
 
       <fieldset class="guide-forms">

--- a/styleguide/results.html
+++ b/styleguide/results.html
@@ -8,7 +8,7 @@ layout: default
 
     <h1>5 Results Based on Your Criteria</h1>
 
-    <a href="{{ site.baseurl }}styleguide/index.html" class="link-more"><i class="fa fa-chevron-left"></i> Edit Criteria</a>
+    <a href="{{ site.baseurl }}/styleguide/index.html" class="link-more"><i class="fa fa-chevron-left"></i> Edit Criteria</a>
 
   </div>
 


### PR DESCRIPTION
In some cases, the Liquid templates followed the `baseurl` tag with a `/`, while in others they did not. This inconsistency became a problem when overriding the `baseurl`, leading to either double slashes or missing slashes, depending on the use.

This PR standardizes to the convention of omitting the trailing slash from the `baseurl`. Without a `baseurl`, all links are relative to the root.