### PR TITLE
Mobile home design audit edits

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -108,7 +108,7 @@
       <div id="major-content">
 
         <label for="major">Specify a major or degree
-          <input id="major" name="major" type="text" placeholder="e.g. Political Science" {{ common_input_attributes }}>
+          <input id="major" name="major" type="text" placeholder="Type a major" {{ common_input_attributes }}>
         </label>
 
         <label for="major-type">Select a type of degree

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -163,7 +163,7 @@
 
         </fieldset>
 
-        <fieldset class="nested_fieldset">
+        <!-- <fieldset class="nested_fieldset">
 
           <legend>Student-to-Faculty Ratio</legend>
           <h1>Student-to-Faculty Ratio</h1>
@@ -189,7 +189,7 @@
             </li>
           </ul>
 
-        </fieldset>
+        </fieldset> -->
 
       </div>
 

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -23,7 +23,7 @@
 
       <div id="name-content" aria-hidden="true">
         <label for="name-school">School name</label>
-        <input id="name-school" name="name" type="text" placeholder="" {{ common_input_attributes }}>
+        <input id="name-school" name="name" type="text" placeholder="e.g. USA University" {{ common_input_attributes }}>
       </div>
 
     </div>

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -227,7 +227,10 @@ header {
 
 .title {
   background: $mid-blue;
-  height: 76px;
+  height: 59px;
+  @include respond-to(tiny-up) {
+      height: 76px;
+    }
 
   > div {
     @include padded-container();
@@ -236,7 +239,7 @@ header {
   h1 {
     @extend .title_heading;
     font-weight: 400;
-    line-height: 1.7;
+    line-height: 1;
     @include respond-to(tiny-up) {
       line-height: 0.7;
     }

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -124,7 +124,7 @@ a {
     padding-bottom: $base-padding-extra;
 
     li {
-      padding: $base-padding-lite $base-padding-extra $base-padding;
+      padding: $base-padding-lite+0.2em $base-padding-extra $base-padding;
       border-bottom: $thin-border-size solid $base-border-color;
 
       &:first-of-type {

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -266,6 +266,7 @@ footer {
 
   p {
     color: $dark-gray;
+    font-weight: 600;
     letter-spacing: 0.4px;
     text-transform: uppercase;
   }

--- a/_sass/base/_buttons.scss
+++ b/_sass/base/_buttons.scss
@@ -18,6 +18,7 @@ input[type="submit"] {
   &.button-primary {
     background-color: $base-button-color;
     color: $white;
+    height: 55px;
     width: 300px;
     -webkit-font-smoothing: antialiased;
 

--- a/_sass/base/_buttons.scss
+++ b/_sass/base/_buttons.scss
@@ -37,7 +37,6 @@ input[type="submit"] {
   &.button-secondary {
     background-color: $secondary-button-color;
     color: $black;
-    width: 230px;
 
     &:hover,
     &:focus {

--- a/_sass/base/_buttons.scss
+++ b/_sass/base/_buttons.scss
@@ -63,7 +63,7 @@ input[type="submit"] {
     background-color: transparent;
     border: 1px solid $white;
     color: $white;
-    height: 100%;
+    height: 76px;
     padding-top: 0.9em;
     padding-bottom: 0.8em;
     -webkit-font-smoothing: antialiased;

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -88,7 +88,8 @@ button {
 .search_category {
   @include font-size($h1);
   font-weight: 400;
-  margin-bottom: 0.3em;
+  //margin-bottom: 0.3em;
+  padding-top: 0.45em;
 }
 
 .key_fact {

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -57,14 +57,14 @@ h4,
 // Buttons
 
 button {
-  @include font-size(1.125);
+  @include font-size($h3);
   font-family: $base-font-family;
   font-weight: bold;
   letter-spacing: 3.6px;
 
   &.button-secondary,
   &.button-compare {
-    @include font-size(1);
+    @include font-size($h6);
     letter-spacing: 2px;
   }
 
@@ -88,7 +88,6 @@ button {
 .search_category {
   @include font-size($h1);
   font-weight: 400;
-  //margin-bottom: 0.3em;
   padding-top: 0.45em;
 }
 

--- a/_sass/base/components/_picc-accordion.scss
+++ b/_sass/base/components/_picc-accordion.scss
@@ -2,7 +2,7 @@ picc-accordion,
 .picc-accordion,
 [is="picc-accordion"] {
   $button-size: 34px;
-  $button-margin: 16px;
+  $button-margin: 9px;
 
   display: block;
   overflow: hidden;

--- a/_sass/base/extends/_buttons.scss
+++ b/_sass/base/extends/_buttons.scss
@@ -5,7 +5,6 @@
   @include transition-delay(0s);
   border-radius: 500px;
   display: inline-block;
-  //line-height: 1.3;
   text-decoration: none;
   text-transform: uppercase;
 }

--- a/_sass/base/extends/_buttons.scss
+++ b/_sass/base/extends/_buttons.scss
@@ -5,7 +5,7 @@
   @include transition-delay(0s);
   border-radius: 500px;
   display: inline-block;
-  line-height: 1.3;
+  //line-height: 1.3;
   text-decoration: none;
   text-transform: uppercase;
 }

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
 
   <div class="container">
 
-    <h1>Did you know?</h1>
+    <h1>By the Numbers</h1>
 
     <div class="carousel">
 
@@ -61,7 +61,7 @@ layout: default
 
     <div>
 
-      <h1>By The Numbers</h1>
+      <h1>Check Out These Schools</h1>
 
       <ul>
         <li><img src="{{ site.baseurl }}/img/education.svg" alt="Education">10 schools that graduate <strong>90% of their students within 4 years</strong></li>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ layout: default
     <h1 class="light_on_dark">Not Sure Where to Start?</h1>
 
     <button class="button-wizard">
-      Help me find schools best suited to me
+      Help me find schools <br>best suited to me
     </button>
 
   </div>


### PR DESCRIPTION
Re: #67 

1. Adjusted header to shrink at mobile sizes.
1. Added line break to ensure wizard button text always breaks in the place we want it to.
1. Shrunk collapsed accordion area to ~52px.
1. Set primary button height to 55px.
1. Set wizard button height to 76px.
1. Set space between Noun Project icon to 14px.
1. Set width of secondary buttons to 280px.
1. Set font size on secondary buttons to 12px.
1. Changes footer to bold.
1. Adds placeholder text to name field.
1. Removes student-to-faculty ratio search option.
1. Changes placeholder text on free enter search for major to 'Type a major'. I thought 'Specify a major' was too academic....but open to suggestion.