### PR TITLE
Make centered things explicit

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -13,6 +13,10 @@
   @include padded-container();
 }
 
+.centered {
+  text-align: center;
+}
+
 .sr-only {
   position: absolute;
   left: -10000px;
@@ -53,7 +57,6 @@ a {
 .section {
   padding-top: $base-padding;
   padding-bottom: $base-padding;
-  text-align: center;
 
   h1 {
     padding-bottom: $base-padding-lite;
@@ -100,11 +103,15 @@ a {
 //============================================
 
 .section-home-start {
+  @extend .centered;
+
   background-color: $secondary-background-color;
   color: $white;
 }
 
 .section-home-facts {
+  @extend .centered;
+
   li {
     border-bottom: $thin-border-size solid $base-border-color;
     margin: $base-padding $base-padding-extra;
@@ -124,6 +131,7 @@ a {
       font-weight: bold;
       line-height: 1;
     }
+
     &:nth-of-type(2) {
       @include font-size($h1);
       line-height: 0.9;
@@ -134,7 +142,9 @@ a {
 }
 
 .section-home-numbers {
+  @extend .centered;
   @extend .section-card_container;
+
   background-color: $tertiary-background-color;
 
   img {
@@ -160,6 +170,8 @@ a {
 }
 
 .section-home-paying {
+  @extend .centered;
+
   > div > div {
     margin-right: auto;
     margin-left: auto;
@@ -170,6 +182,8 @@ a {
 }
 
 .section-home-decision {
+  @extend .centered;
+
   background-color: $quaternary-background-color;
   color: $white;
   padding-right: 0;
@@ -220,6 +234,8 @@ a {
 }
 
 .search_form-submit {
+  @extend .centered;
+
   border-top: $thick-border-size solid $base-border-color;
   padding-top: $base-padding-large;
   text-align: center;
@@ -229,7 +245,7 @@ a {
   }
 
   div {
-    @extend .new_line;
+    // @extend .new_line;
   }
 }
 

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -80,7 +80,6 @@ a {
 
 .section-card_container-school {
   @extend .section-card_container;
-  text-align: left;
 
   h1 {
     padding: 0;
@@ -254,11 +253,6 @@ a {
 //============================================
 
 .results {
-  section,
-  div {
-    text-align: left;
-  }
-
   div.container {
     padding-bottom: $base-padding;
 
@@ -286,13 +280,6 @@ a {
 
 // Individual school pages
 //============================================
-
-.school {
-  section,
-  div {
-    text-align: left;
-  }
-}
 
 .school-section {
   border-bottom: $regular-border-size solid $base-border-color;

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -13,10 +13,6 @@
   @include padded-container();
 }
 
-.centered {
-  text-align: center;
-}
-
 .sr-only {
   position: absolute;
   left: -10000px;

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -122,7 +122,7 @@ a {
     }
   }
 
-  span {
+  b {
     color: $lime-green;
     display: block;
 

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -121,7 +121,7 @@ a {
     }
   }
 
-  b {
+  strong {
     color: $lime-green;
     display: block;
 

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -14,6 +14,7 @@
 
 // Extends
 @import 'extends/buttons';
+@import 'extends/centered';
 
 // Typography and Elements
 @import 'buttons';

--- a/_sass/base/extends/_centered.scss
+++ b/_sass/base/extends/_centered.scss
@@ -1,0 +1,5 @@
+// this is kind of silly, but ¯\_(ツ)_/¯
+.centered {
+  text-align: center;
+}
+

--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@ layout: default
     </a>
 
     <ul>
-
+      {% for i in (1..3) %}
       <li>
         College graduates earn 
-        <span>85%</span><span>more</span> 
+        <b class="big">85%</b> <b>more</b> 
         than those with just a <br>high school diploma
 
         <!-- <div class="share">
@@ -49,29 +49,7 @@ layout: default
           <a>Twitter</a>
         </div> -->
       </li>
-
-      <li>
-        College graduates earn 
-        <span>85%</span><span>more</span> 
-        than those with just a <br>high school diploma
-
-        <!-- <div class="share">
-          <a>Facebook</a>
-          <a>Twitter</a>
-        </div> -->
-      </li>
-
-      <li>
-        College graduates earn 
-        <span>85%</span><span>more</span> 
-        than those with just a <br>high school diploma
-
-        <!-- <div class="share">
-          <a>Facebook</a>
-          <a>Twitter</a>
-        </div> -->
-      </li>
-
+      {% endfor %}
     </ul>
 
   </div>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ layout: default
       {% for i in (1..3) %}
       <li>
         College graduates earn 
-        <b class="big">85%</b> <b>more</b> 
+        <strong class="big">85%</strong> <strong>more</strong>
         than those with just a <br>high school diploma
 
         <!-- <div class="share">

--- a/school/index.html
+++ b/school/index.html
@@ -58,6 +58,6 @@ body_scripts:
 
 <!--
 <section>
-  {% include search-form.html %}
+  {# include search-form.html #}
 </section>
 -->


### PR DESCRIPTION
This PR introduces a general-purpose `centered` class and "applies" it (with `@extend`) to a bunch of the home page sections, which obviates the need for "undoing" the centered alignment with `text-align: left` elsewhere.

There are also some other random tweaks in here, including:

1. turning the key facts bits into a template loop so that they're easier to tweak
2. using `<b>` instead of `<span>` tags for the big, important key facts snippets
3. fixing an HTML comment error introduced by commented elements in the search form