### PR TITLE
Import environment variables into template context

### DIFF
--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,0 +1,21 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+
+module Jekyll
+
+  class EnvironmentVariablesGenerator < Generator
+
+    def generate(site)
+      if ENV['API_BASE_URL']
+        site.config['api']['baseurl'] = ENV['API_BASE_URL']
+      end
+      if ENV['API_KEY']
+        site.config['api']['key'] = ENV['API_KEY']
+      end
+      puts "API: ------------------"
+      puts site.config['api']
+      puts "------------------"
+    end
+
+  end
+
+end

--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -11,9 +11,9 @@ module Jekyll
       if ENV['API_KEY']
         site.config['api']['key'] = ENV['API_KEY']
       end
-      puts "API: ------------------"
-      puts site.config['api']
-      puts "------------------"
+      # puts "API: ------------------"
+      # puts site.config['api']
+      # puts "------------------"
     end
 
   end

--- a/js/api.js
+++ b/js/api.js
@@ -4,7 +4,8 @@
 (function(exports) {
   
   var API = {
-    url: '{{ site.api.baseurl }}'
+    url: '{{ site.api.baseurl }}',
+    key: '{{ site.api.key }}'
   };
 
   API.get = function(uri, params, done) {
@@ -13,12 +14,15 @@
       done = params;
     } else if (params) {
       if (typeof params === 'object') {
+        if (API.key) params.api_key = API.key;
         params = querystring.stringify(params);
+      } else if (API.key) {
+        params += '&api_key=' + API.key;
       }
       uri = join([uri, params], '?');
     }
     var url = join([API.url, uri], '/');
-    console.debug('[API] getting: "%s"', url);
+    console.debug('[API] get: "%s"', url);
     return d3.json(url, done);
   };
 


### PR DESCRIPTION
This PR adds a modified version of [this Jekyll plugin](https://gist.github.com/nicolashery/5756478) that adds the `API_BASE_URL` and `API_KEY` environment variables to Jekyll's `site.config`, which makes them available as template variables `site.api.baseurl` and `site.api.key`, respectively.