### PR TITLE
[WIP] More school page data

### DIFF
--- a/_data/national_stats.yaml
+++ b/_data/national_stats.yaml
@@ -6,50 +6,10 @@ net_price_public:
   min: -6359
   max: 32921
   median: 8446
-net_price_public_income1:
-  min: -6876
-  max: 30266
-  median: 7373
-net_price_public_income2:
-  min: -9453
-  max: 34428
-  median: 8355
-net_price_public_income3:
-  min: -5973
-  max: 35216
-  median: 10606
-net_price_public_income4:
-  min: -7562
-  max: 31320
-  median: 12627
-net_price_public_income5:
-  min: -5668
-  max: 31217
-  median: 13187
 net_price_private:
   min: -19360
   max: 87414
   median: 17706
-net_price_private_income1:
-  min: -20147
-  max: 85287
-  median: 16114
-net_price_private_income2:
-  min: -19283
-  max: 72484
-  median: 17269.5
-net_price_private_income3:
-  min: -17803
-  max: 89010
-  median: 19539
-net_price_private_income4:
-  min: -15830
-  max: 89010
-  median: 21987
-net_price_private_income5:
-  min: -3076
-  max: 76664
-  median: 23337.5
 completion_rate_4:
   min: 0
   max: 1

--- a/_data/national_stats.yaml
+++ b/_data/national_stats.yaml
@@ -22,3 +22,7 @@ median_earnings:
   min: null
   max: null
   median: null
+retention_rate:
+  min: 0
+  max: 1
+  median: 0.65

--- a/_data/national_stats.yaml
+++ b/_data/national_stats.yaml
@@ -2,14 +2,54 @@ SAT_avg:
   min: null
   max: null
   median: null
-average_price_public:
+net_price_public:
   min: -6359
   max: 32921
   median: 8446
-average_price_private:
+net_price_public_income1:
+  min: -6876
+  max: 30266
+  median: 7373
+net_price_public_income2:
+  min: -9453
+  max: 34428
+  median: 8355
+net_price_public_income3:
+  min: -5973
+  max: 35216
+  median: 10606
+net_price_public_income4:
+  min: -7562
+  max: 31320
+  median: 12627
+net_price_public_income5:
+  min: -5668
+  max: 31217
+  median: 13187
+net_price_private:
   min: -19360
   max: 87414
   median: 17706
+net_price_private_income1:
+  min: -20147
+  max: 85287
+  median: 16114
+net_price_private_income2:
+  min: -19283
+  max: 72484
+  median: 17269.5
+net_price_private_income3:
+  min: -17803
+  max: 89010
+  median: 19539
+net_price_private_income4:
+  min: -15830
+  max: 89010
+  median: 21987
+net_price_private_income5:
+  min: -3076
+  max: 76664
+  median: 23337.5
 completion_rate_4:
   min: 0
   max: 1

--- a/_data/stats.js
+++ b/_data/stats.js
@@ -9,8 +9,21 @@ var valuesByColumn = {};
 
 var columns = {
   'SAT_avg':        'SAT_avg',
-  'NPT4_PUB':       'average_price_public',
-  'NPT4_PRIV':      'average_price_private',
+
+  'NPT4_PUB':       'net_price_public',
+  'NPT41_PUB':      'net_price_public_income1',
+  'NPT42_PUB':      'net_price_public_income2',
+  'NPT43_PUB':      'net_price_public_income3',
+  'NPT44_PUB':      'net_price_public_income4',
+  'NPT45_PUB':      'net_price_public_income5',
+
+  'NPT4_PRIV':      'net_price_private',
+  'NPT41_PRIV':     'net_price_private_income1',
+  'NPT42_PRIV':     'net_price_private_income2',
+  'NPT43_PRIV':     'net_price_private_income3',
+  'NPT44_PRIV':     'net_price_private_income4',
+  'NPT45_PRIV':     'net_price_private_income5',
+
   'C150_4':         'completion_rate_4',
   'C150_L4':        'completion_rate_l4',
   'earn_2002_p10':  'median_earnings'

--- a/_data/stats.js
+++ b/_data/stats.js
@@ -8,33 +8,39 @@ var write = tito.createWriteStream('csv');
 var valuesByColumn = {};
 
 var columns = {
-  'SAT_avg':        'SAT_avg',
+  'SAT_avg': 'SAT_avg',
 
-  'NPT4_PUB':       'net_price_public',
+  'net_price_public': 'NPT4_PUB',
   /*
-  'NPT41_PUB':      'net_price_public_income1',
-  'NPT42_PUB':      'net_price_public_income2',
-  'NPT43_PUB':      'net_price_public_income3',
-  'NPT44_PUB':      'net_price_public_income4',
-  'NPT45_PUB':      'net_price_public_income5',
+  'net_price_public_income1': 'NPT41_PUB',
+  'net_price_public_income2': 'NPT42_PUB',
+  'net_price_public_income3': 'NPT43_PUB',
+  'net_price_public_income4': 'NPT44_PUB',
+  'net_price_public_income5': 'NPT45_PUB',
   */
 
-  'NPT4_PRIV':      'net_price_private',
+  'net_price_private': 'NPT4_PRIV',
   /*
-  'NPT41_PRIV':     'net_price_private_income1',
-  'NPT42_PRIV':     'net_price_private_income2',
-  'NPT43_PRIV':     'net_price_private_income3',
-  'NPT44_PRIV':     'net_price_private_income4',
-  'NPT45_PRIV':     'net_price_private_income5',
+  'net_price_private_income1': 'NPT41_PRIV',
+  'net_price_private_income2': 'NPT42_PRIV',
+  'net_price_private_income3': 'NPT43_PRIV',
+  'net_price_private_income4': 'NPT44_PRIV',
+  'net_price_private_income5': 'NPT45_PRIV',
   */
 
-  'C150_4':         'completion_rate_4',
-  'C150_L4':        'completion_rate_l4',
-  'earn_2002_p10':  'median_earnings'
+  'completion_rate_4': 'C150_4',
+  'completion_rate_l4': 'C150_L4',
+  'median_earnings': 'earn_2002_p10',
+
+  'retention_rate': function(d) {
+    with (d) {
+      return ((UGDS * (PPTUG_EF || PPTUG_EF2) * (RET_PT4 || RET_PTL4)) + ((UGDS-(UGDS * (PPTUG_EF || PPTUG_EF2))) * (RET_FT4 || RET_FTL4))) / UGDS;
+    }
+  }
 };
 
-for (var src in columns) {
-  valuesByColumn[columns[src]] = [];
+for (var dest in columns) {
+  valuesByColumn[dest] = [];
 }
 
 var stats = {
@@ -47,9 +53,12 @@ process.stdin
   .pipe(read)
   .on('data', function(d) {
     // console.log('read row:', JSON.stringify(d).substr(0, 100), '...');
-    for (var src in columns) {
-      var value = number(d[src]);
-      valuesByColumn[columns[src]].push(value);
+    for (var dest in columns) {
+      var src = columns[dest];
+      var value = number(typeof src === 'function'
+        ? src.call(this, d, dest)
+        : d[src]);
+      valuesByColumn[dest].push(value);
     }
   })
   .on('end', output);

--- a/_data/stats.js
+++ b/_data/stats.js
@@ -11,18 +11,22 @@ var columns = {
   'SAT_avg':        'SAT_avg',
 
   'NPT4_PUB':       'net_price_public',
+  /*
   'NPT41_PUB':      'net_price_public_income1',
   'NPT42_PUB':      'net_price_public_income2',
   'NPT43_PUB':      'net_price_public_income3',
   'NPT44_PUB':      'net_price_public_income4',
   'NPT45_PUB':      'net_price_public_income5',
+  */
 
   'NPT4_PRIV':      'net_price_private',
+  /*
   'NPT41_PRIV':     'net_price_private_income1',
   'NPT42_PRIV':     'net_price_private_income2',
   'NPT43_PRIV':     'net_price_private_income3',
   'NPT44_PRIV':     'net_price_private_income4',
   'NPT45_PRIV':     'net_price_private_income5',
+  */
 
   'C150_4':         'completion_rate_4',
   'C150_L4':        'completion_rate_l4',

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -16,8 +16,8 @@
 
           this.min = getAttr(this, 'min', 0);
           this.max = getAttr(this, 'max', 1);
-          this.value = getAttr(this, 'value', 0);
-          this.average = getAttr(this, 'average', 0);
+          this.value = getAttr(this, 'value');
+          this.average = getAttr(this, 'average');
 
           this.update();
         }},
@@ -49,16 +49,35 @@
           };
 
           var bar = this.querySelector('.' + CLASS_PREFIX + 'bar');
+          // prevent the bar from exceeding the height
+          var value = Math.min(this.value, this.max);
+          bar.style.setProperty('height', percent(value));
+
           var line = this.querySelector('.' + CLASS_PREFIX + 'line');
 
-          bar.style.setProperty('height', percent(this.value));
-          line.style.setProperty('bottom', percent(this.average));
+          var average = this.average;
+          var difference;
+          // console.log('average:', this.getAttribute('average'), '->', average);
+          if (isNaN(average)) {
+            line.style.setProperty('display', 'none');
+            classify(this, {
+              'above-average': false,
+              'below-average': false,
+              'about-average': false
+            });
+          } else {
+            difference = value - average;
+            line.style.removeProperty('display');
+            line.style.setProperty('bottom', percent(this.average));
+            // TODO: get threshold from attribute
+            var aboutThreshold = .05 * (this.max - this.min);
+            classify(this, {
+              'above-average': difference > 0,
+              'below-average': difference < 0,
+              'about-average': Math.abs(difference) <= aboutThreshold
+            });
+          }
 
-          var aboveAverage = this.value >= this.average;
-          classify(this, {
-            'above-average': aboveAverage,
-            'below-average': !aboveAverage
-          });
 
           delete this.__timeout;
 
@@ -80,7 +99,7 @@
             return this.__max;
           },
           set: function(value) {
-            this.__max = number(value, 0);
+            this.__max = number(value, 1);
             deferUpdate(this);
           }
         },
@@ -90,7 +109,7 @@
             return this.__value;
           },
           set: function(value) {
-            this.__value = number(value, 0);
+            this.__value = number(value);
             deferUpdate(this);
           }
         },
@@ -100,7 +119,7 @@
             return this.__average;
           },
           set: function(value) {
-            this.__average = number(value, 0);
+            this.__average = number(value);
             deferUpdate(this);
           }
         }
@@ -125,8 +144,10 @@
   }
 
   function number(value, fallback) {
-    var num = +value;
-    return isNaN(value) ? (fallback || 0) : num;
+    var num = String(value).length ? +value : NaN;
+    // console.log('number(', value, ') ->', num);
+    if (arguments.length < 2) fallback = NaN;
+    return isNaN(num) ? fallback : num;
   }
 
   function classify(el, classes) {

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -69,8 +69,7 @@
             difference = value - average;
             line.style.removeProperty('display');
             line.style.setProperty('bottom', percent(this.average));
-            // TODO: get threshold from attribute
-            var aboutThreshold = .05 * (this.max - this.min);
+            var aboutThreshold = getAttr(this, 'about-threshold', .05) * (this.max - this.min);
             classify(this, {
               'above-average': difference > 0,
               'below-average': difference < 0,

--- a/js/picc.js
+++ b/js/picc.js
@@ -239,11 +239,22 @@
     }
   };
 
-  picc.access.averageCost = function(d) {
+  picc.access.netPrice = function(d) {
     var key = picc.access.publicPrivate(d);
     return key
-      ? picc.nullify(d.avg_net_price[key])
+      ? d.avg_net_price
+        ? picc.nullify(d.avg_net_price[key])
+        : picc.nullify(d.net_price[key].average)
       : null;
+  };
+
+  picc.access.netPriceByIncomeLevel = function(level) {
+    return function(d) {
+      var key = picc.access.publicPrivate(d);
+      return d.net_price
+        ? picc.nullify(d.net_price[key].by_income_level[level])
+        : null;
+    };
   };
 
   picc.access.yearDesignation = function(d) {

--- a/js/picc.js
+++ b/js/picc.js
@@ -279,6 +279,19 @@
       : null;
   };
 
+  picc.access.retentionRate = function(d) {
+    var designation = picc.access.yearDesignation(d);
+    var partTimeShare = d.part_time_share[1] || d.part_time_share[2];
+    var retention = d.retention_rate[designation];
+    var partTimeRate = retention ? retention.part_time : 0;
+    var fullTime = retention ? retention.full_time : 0;
+    var size = d.size;
+    return (
+      (size * partTimeShare * partTimeRate) +
+      ((size - size * partTimeShare) * fullTime)
+    ) / size;
+  };
+
   picc.access.specialDesignation = function(d) {
     var designations = [];
 

--- a/js/school.js
+++ b/js/school.js
@@ -33,13 +33,19 @@
       // TODO
     },
 
-    average_cost: format.dollars(access.averageCost),
+    average_cost: format.dollars(access.netPrice),
     average_cost_meter: {
       '@max':     access.nationalStat('max', access.publicPrivate),
       '@average': access.nationalStat('median', access.publicPrivate),
-      '@value':   access.averageCost,
+      '@value':   access.netPrice,
       '@title':   debugMeterTitle
     },
+
+    net_price_income1: format.dollars(access.netPriceByIncomeLevel('0-30000')),
+    net_price_income2: format.dollars(access.netPriceByIncomeLevel('30001-48000')),
+    net_price_income3: format.dollars(access.netPriceByIncomeLevel('48001-75000')),
+    net_price_income4: format.dollars(access.netPriceByIncomeLevel('75001-110000')),
+    net_price_income5: format.dollars(access.netPriceByIncomeLevel('110001-plus')),
 
     grad_rate: format.percent(access.completionRate),
     grad_rate_meter: {

--- a/js/school.js
+++ b/js/school.js
@@ -128,6 +128,7 @@
   window.addEventListener('load', function() {
     var sectionId = location.hash.substr(1);
     if (!sectionId) return;
+    var found;
     d3.selectAll('.picc-accordion')
       .each(function() {
         if (this.id === sectionId) {
@@ -136,8 +137,14 @@
           var content = document.getElementById(button.getAttribute('aria-controls'));
           content.setAttribute('aria-hidden', 'false');
           content.classList.remove('hidden');
+          found = this;
         }
       });
+
+      if (found) {
+        location.hash = '';
+        location.hash = '#' + found.id;
+      }
   });
 
   function getSchoolId() {

--- a/js/school.js
+++ b/js/school.js
@@ -58,6 +58,12 @@
     average_salary_meter: {
       '@value': access.medianEarnings,
       '@title': debugMeterTitle
+    },
+
+    retention_rate_value: format.percent(picc.access.retentionRate),
+    retention_rate_meter: {
+      '@value': picc.access.retentionRate,
+      '@title': debugMeterTitle
     }
 
   };

--- a/js/school.js
+++ b/js/school.js
@@ -43,7 +43,6 @@
 
     grad_rate: format.percent(access.completionRate),
     grad_rate_meter: {
-      '@max':     access.nationalStat('max', access.yearDesignation),
       '@average': access.nationalStat('median', access.yearDesignation),
       '@value':   access.completionRate,
       '@title':   debugMeterTitle

--- a/school/index.html
+++ b/school/index.html
@@ -80,12 +80,16 @@ defaults:
         <div id="key-stats" class="school-meters">
           <figure class="meter">
             <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
-            <picc-meter class="cost"
+            <picc-meter
+            {% capture average_cost_meter %}
+              class="cost"
               data-bind="average_cost_meter"
-              data-max-public="{{ site.data.national_stats.average_price_public.max|default:80000 }}"
-              data-max-private="{{ site.data.national_stats.average_price_private.max|default:80000 }}"
+              data-max-public="{{ site.data.national_stats.average_price_public.max }}"
+              data-max-private="{{ site.data.national_stats.average_price_private.max }}"
               data-median-public="{{ site.data.national_stats.average_price_public.median }}"
-              data-median-private="{{ site.data.national_stats.average_price_private.median }}">
+              data-median-private="{{ site.data.national_stats.average_price_private.median }}"
+            {% endcapture %}
+            {{ average_cost_meter }}>
             </picc-meter>
             <figcaption>
               <span data-bind="average_cost"></span>
@@ -94,11 +98,15 @@ defaults:
 
           <figure class="meter">
             <h2 class="figure-heading constrain_width">Graduation Rate</h2>
-            <picc-meter class="graduation"
+            <picc-meter
+            {% capture grad_rate_meter %}
+              class="graduation"
               data-bind="grad_rate_meter"
               max="1"
               data-median-four_year="{{ site.data.national_stats.completion_rate_4.median }}"
-              data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}">
+              data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}"
+            {% endcapture %}
+            {{ grad_rate_meter }}>
             </picc-meter>
             <figcaption>
               <span data-bind="grad_rate"></span>
@@ -107,10 +115,14 @@ defaults:
 
           <figure class="meter">
             <h2 class="figure-heading constrain_width">Average Salary</h2>
-            <picc-meter class="earnings"
+            <picc-meter
+            {% capture average_salary_meter %}
+              class="earnings"
               data-bind="average_salary_meter"
               {% if site.data.median_earnings.max %}max="{{ site.data.median_earnings.max }}"{% else %}max="{{ page.defaults.median_earnings.max }}"{% endif %}
-              average="{{ site.data.median_earnings.median }}">
+              average="{{ site.data.median_earnings.median }}"
+            {% endcapture %}
+            {{ average_salary_meter }}>
             </picc-meter>
             <figcaption>
               <span data-bind="average_salary"></span>
@@ -136,12 +148,8 @@ defaults:
 
                   <figure class="meter">
                     <h2 class="figure-heading">Average Net Price</h2>
-                    <picc-meter id="cost-meter" class="cost"
-                      data-bind="average_cost_meter"
-                      data-max-public="{{ site.data.national_stats.average_price_public.max }}"
-                      data-max-private="{{ site.data.national_stats.average_price_private.max }}"
-                      data-median-public="{{ site.data.national_stats.average_price_public.median }}"
-                      data-median-private="{{ site.data.national_stats.average_price_private.median }}">
+                    <picc-meter id="cost-meter"
+                      {{ average_cost_meter }}>
                     </picc-meter>
                     <figcaption>
                       <i class="fa average-arrow" data-meter="cost-meter"></i>

--- a/school/index.html
+++ b/school/index.html
@@ -334,7 +334,7 @@ defaults:
         </div>
 
         <div class="section-card_container-school">
-          <div class="picc-accordion school-two_col">
+          <div id="earnings" class="picc-accordion school-two_col">
             <div>
               <h1 class="search_category">
                 <a aria-expanded="false" aria-controls="earnings-content">
@@ -346,13 +346,12 @@ defaults:
                 <div class="school-two_col-left centered">
                   <figure class="meter">
                     <h2 class="figure-heading">Average Salary <br>After Leaving School</h2>
-                    <picc-meter class="cost" data-bind="average_cost_meter"
-                      max="100000"
-                      value="33209"
-                      average="60000">
+                    <picc-meter id="salary-meter"
+                      {{ average_salary_meter }}>
                     </picc-meter>
                     <figcaption>
-                      <span data-bind="average_cost">$43,900</span>
+                      <i class="fa average-cost" data-meter="salary-meter"></i>
+                      <span data-bind="average_salary">$XX,XXX</span>
                     </figcaption>
                   </figure>
                 </div>
@@ -360,12 +359,15 @@ defaults:
                 <div class="school-two_col-right centered">
                   <figure class="meter">
                     <h2 class="figure-heading">Former Students <br>Earning Less Than $25K</h2>
-                    <picc-meter class="cost" data-bind="average_cost_meter"
-                      max="100000"
-                      value="33209"
-                      average="60000">
+                    <picc-meter class="earnings"
+                      id="low-income-meter"
+                      data-bind="low_income_earnings_meter"
+                      max="{# TODO #}"
+                      value="{# TODO #}"
+                      average="{# TODO #}">
                     </picc-meter>
                     <figcaption>
+                      <i class="fa average-arrow" data-meter="low-income-meter"></i>
                       <span data-bind="average_cost">15%</span>
                     </figcaption>
                   </figure>

--- a/school/index.html
+++ b/school/index.html
@@ -84,10 +84,10 @@ defaults:
             {% capture average_cost_meter %}
               class="cost"
               data-bind="average_cost_meter"
-              data-max-public="{{ site.data.national_stats.average_price_public.max }}"
-              data-max-private="{{ site.data.national_stats.average_price_private.max }}"
-              data-median-public="{{ site.data.national_stats.average_price_public.median }}"
-              data-median-private="{{ site.data.national_stats.average_price_private.median }}"
+              data-max-public="{{ site.data.national_stats.net_price_public.max }}"
+              data-max-private="{{ site.data.national_stats.net_price_private.max }}"
+              data-median-public="{{ site.data.national_stats.net_price_public.median }}"
+              data-median-private="{{ site.data.national_stats.net_price_private.median }}"
             {% endcapture %}
             {{ average_cost_meter }}>
             </picc-meter>

--- a/school/index.html
+++ b/school/index.html
@@ -9,6 +9,10 @@ stylesheets:
   - vendor/leaflet.css
 body_scripts:
   - school.js
+
+defaults:
+  median_earnings:
+    max: 150000
 ---
 
 <section id="error" class="container hidden">
@@ -78,8 +82,8 @@ body_scripts:
             <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
             <picc-meter class="cost"
               data-bind="average_cost_meter"
-              data-max-public="{{ site.data.national_stats.average_price_public.max }}"
-              data-max-private="{{ site.data.national_stats.average_price_private.max }}"
+              data-max-public="{{ site.data.national_stats.average_price_public.max|default:80000 }}"
+              data-max-private="{{ site.data.national_stats.average_price_private.max|default:80000 }}"
               data-median-public="{{ site.data.national_stats.average_price_public.median }}"
               data-median-private="{{ site.data.national_stats.average_price_private.median }}">
             </picc-meter>
@@ -93,8 +97,6 @@ body_scripts:
             <picc-meter class="graduation"
               data-bind="grad_rate_meter"
               max="1"
-              data-max-four_year="{{ site.data.national_stats.completion_rate_4.max }}"
-              data-max-lt_four_year="{{ site.data.national_stats.completion_rate_l4.max }}"
               data-median-four_year="{{ site.data.national_stats.completion_rate_4.median }}"
               data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}">
             </picc-meter>
@@ -107,7 +109,7 @@ body_scripts:
             <h2 class="figure-heading constrain_width">Average Salary</h2>
             <picc-meter class="earnings"
               data-bind="average_salary_meter"
-              max="{{ site.data.median_earnings.max }}"
+              {% if site.data.median_earnings.max %}max="{{ site.data.median_earnings.max }}"{% else %}max="{{ page.defaults.median_earnings.max }}"{% endif %}
               average="{{ site.data.median_earnings.median }}">
             </picc-meter>
             <figcaption>

--- a/school/index.html
+++ b/school/index.html
@@ -156,7 +156,9 @@ defaults:
                       <span data-bind="average_cost"></span>
                     </figcaption>
                   </figure>
+                  <!--
                   <p>Assumes <strong>$XX,XXX</strong> in tuition and fees, <strong>$X,XXX</strong> in other costs like room and board, books and supplies, and other personal expenses.</p>
+                  -->
 
                 </div>
 
@@ -185,11 +187,11 @@ defaults:
                         <td data-bind="net_price_income3">$XX,XXX</td>
                       </tr>
                       <tr>
-                        <td>$75,001-$130,000</td>
+                        <td>$75,001-$110,000</td>
                         <td data-bind="net_price_income4">$XX,XXX</td>
                       </tr>
                       <tr>
-                        <td>$130,001+</td>
+                        <td>$110,001+</td>
                         <td data-bind="net_price_income5">$XX,XXX</td>
                       </tr>
                     </tbody>

--- a/school/index.html
+++ b/school/index.html
@@ -92,7 +92,7 @@ defaults:
             {{ average_cost_meter }}>
             </picc-meter>
             <figcaption>
-              <span data-bind="average_cost"></span>
+              <span data-bind="average_cost">$XX,XXX</span>
             </figcaption>
           </figure>
 
@@ -109,7 +109,7 @@ defaults:
             {{ grad_rate_meter }}>
             </picc-meter>
             <figcaption>
-              <span data-bind="grad_rate"></span>
+              <span data-bind="grad_rate">XX%</span>
             </figcaption>
           </figure>
 
@@ -125,7 +125,7 @@ defaults:
             {{ average_salary_meter }}>
             </picc-meter>
             <figcaption>
-              <span data-bind="average_salary"></span>
+              <span data-bind="average_salary">$XX,XXX</span>
             </figcaption>
           </figure>
         </div>
@@ -288,7 +288,7 @@ defaults:
         </div>
 
         <div class="section-card_container-school">
-          <div class="picc-accordion school-two_col">
+          <div id="graduation" class="picc-accordion school-two_col">
             <div>
               <h1 class="search_category">
                 <a aria-expanded="false" aria-controls="graduation-content">
@@ -301,13 +301,12 @@ defaults:
                 <div class="school-two_col-left centered">
                   <figure class="meter">
                     <h2 class="figure-heading constrain_width">Graduation Rate</h2>
-                    <picc-meter class="cost" data-bind="average_cost_meter"
-                      max="100000"
-                      value="33209"
-                      average="60000">
+                    <picc-meter id="grad-meter"
+                      {{ grad_rate_meter }}>
                     </picc-meter>
                     <figcaption>
-                      <span data-bind="average_cost">60%</span>
+                      <i class="fa average-arrow" data-meter="grad-meter"></i>
+                      <span data-bind="grad_rate">60%</span>
                     </figcaption>
                   </figure>
                 </div>
@@ -315,13 +314,16 @@ defaults:
                 <div class="school-two_col-right centered">
                   <figure class="meter">
                     <h2 class="figure-heading">Students Who Return <br>After Their First Year</h2>
-                    <picc-meter class="cost" data-bind="average_cost_meter"
-                      max="100000"
-                      value="33209"
-                      average="60000">
+                    <picc-meter id="return-meter"
+                      class="return"
+                      data-bind="return_rate_meter"
+                      max="{# TODO #}"
+                      value="{# TODO #}"
+                      average="{# TODO #}">
                     </picc-meter>
                     <figcaption>
-                      <span data-bind="average_cost">82%</span>
+                      <i class="fa average-cost" data-meter="return-meter"></i>
+                      <span data-bind="return_rate">XX%</span>
                     </figcaption>
                   </figure>
                 </div>

--- a/school/index.html
+++ b/school/index.html
@@ -159,7 +159,6 @@ defaults:
                   <!--
                   <p>Assumes <strong>$XX,XXX</strong> in tuition and fees, <strong>$X,XXX</strong> in other costs like room and board, books and supplies, and other personal expenses.</p>
                   -->
-
                 </div>
 
                 <div class="school-two_col-right">
@@ -256,8 +255,9 @@ defaults:
                   <div>
                     <h2>Average Monthly Loan Payment</h2>
                     <strong class="fact_number" data-bind="average_monthly_loan_payment">$XXX<span>/mo</span></strong>
-                    <p>This is about equal to:</p>
 
+                    <!--
+                    <p>This is about equal to:</p>
                     <ul class="group_inline" data-bind="loan_payment_equivalents">
                       <li>
                         <div class="group_inline-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
@@ -274,6 +274,7 @@ defaults:
                         <div class="group_inline-right">XX% of a month's rent</div>
                       </li>
                     </ul>
+                    -->
                   </div>
 
                   <div>

--- a/school/index.html
+++ b/school/index.html
@@ -174,23 +174,23 @@ defaults:
                     <tbody>
                       <tr>
                         <td>$0-$30,000</td>
-                        <td>$5,000</td>
+                        <td data-bind="net_price_income1">$X,XXX</td>
                       </tr>
                       <tr>
                         <td>$30,001-$48,000</td>
-                        <td>$XX,XXX</td>
+                        <td data-bind="net_price_income2">$XX,XXX</td>
                       </tr>
                       <tr>
                         <td>$48,001-$75,000</td>
-                        <td>$XX,XXX</td>
+                        <td data-bind="net_price_income3">$XX,XXX</td>
                       </tr>
                       <tr>
                         <td>$75,001-$130,000</td>
-                        <td>$XX,XXX</td>
+                        <td data-bind="net_price_income4">$XX,XXX</td>
                       </tr>
                       <tr>
                         <td>$130,001+</td>
-                        <td>$XX,XXX</td>
+                        <td data-bind="net_price_income5">$XX,XXX</td>
                       </tr>
                     </tbody>
                   </table>
@@ -204,7 +204,7 @@ defaults:
         </div>
 
         <div class="section-card_container-school">
-          <div class="picc-accordion school-two_col">
+          <div id="finaid" class="picc-accordion school-two_col">
             <div>
               <h1 class="search_category">
                 <a aria-expanded="false" aria-controls="finaid-content">
@@ -218,13 +218,16 @@ defaults:
 
                   <figure class="meter">
                     <h2 class="figure-heading">Students Who Have Defaulted on Loans</h2>
-                    <picc-meter class="cost" data-bind="average_cost_meter"
-                      max="100000"
-                      value="33209"
-                      average="60000">
+                    <picc-meter id="default-meter"
+                      class="default"
+                      data-bind="default_rate_meter"
+                      max="1"
+                      value="{# TODO #}"
+                      average="{{ site.data.national_stats.default_rate.median }}">
                     </picc-meter>
                     <figcaption>
-                      <span data-bind="average_cost">12%</span>
+                      <i class="fa average-arrow" data-meter="default-meter"></i>
+                      <span data-bind="default_rate">XX%</span>
                     </figcaption>
                   </figure>
 
@@ -244,34 +247,36 @@ defaults:
 
                   <div>
                     <h2>Average Total Debt</h2>
-                    <strong class="fact_number">$60,000</strong>
+                    <strong class="fact_number" data-bind="average_total_debt">$XX,XXX</strong>
                     <p>For those students who graduated</p>
                   </div>
 
                   <div>
                     <h2>Average Monthly Loan Payment</h2>
-                    <strong class="fact_number">$250<span>/mo</span></strong>
+                    <strong class="fact_number" data-bind="average_monthly_loan_payment">$XXX<span>/mo</span></strong>
                     <p>This is about equal to:</p>
 
-                    <ul class="group_inline">
+                    <ul class="group_inline" data-bind="loan_payment_equivalents">
                       <li>
                         <div class="group_inline-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-                        <div class="group_inline-right">18% of your monthly salary</div>
+                        <div class="group_inline-right" data-bind="text">
+                          XX% of a graduate's monthly salary
+                        </div>
                       </li>
                       <li>
                         <div class="group_inline-left"><img src="{{ site.baseurl }}/img/education.svg" alt= class="school-callout""Education"></div>
-                        <div class="group_inline-right">A monthly car payment</div>
+                        <div class="group_inline-right">X months' car payments</div>
                       </li>
                       <li>
                         <div class="group_inline-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-                        <div class="group_inline-right">Half of a month's rent</div>
+                        <div class="group_inline-right">XX% of a month's rent</div>
                       </li>
                     </ul>
                   </div>
 
                   <div>
                     <h2>Students Receiving Federal Aid</h2>
-                    <strong class="fact_number">70%</strong>
+                    <strong class="fact_number" data-bind="federal_aid_percentage">XX%</strong>
                     <p>Brief explanation of what federal aid is and means. Nunc eu consectutur purus.</p>
                   </div>
 

--- a/school/index.html
+++ b/school/index.html
@@ -316,17 +316,17 @@ defaults:
 
                 <div class="school-two_col-right centered">
                   <figure class="meter">
-                    <h2 class="figure-heading">Students Who Return <br>After Their First Year</h2>
-                    <picc-meter id="return-meter"
-                      class="return"
-                      data-bind="return_rate_meter"
-                      max="{# TODO #}"
-                      value="{# TODO #}"
-                      average="{# TODO #}">
+                    <h2 class="figure-heading">Students Who Return <br>Each Year</h2>
+                    <picc-meter id="retention-meter"
+                      class="graduation"
+                      data-bind="retention_rate_meter"
+                      about-threshold=".03"
+                      max="1"
+                      average="{{ site.data.national_stats.retention_rate.median }}">
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-cost" data-meter="return-meter"></i>
-                      <span data-bind="return_rate">XX%</span>
+                      <i class="fa average-arrow" data-meter="retention-meter"></i>
+                      <span data-bind="retention_rate_value">XX%</span>
                     </figcaption>
                   </figure>
                 </div>

--- a/school/index.html
+++ b/school/index.html
@@ -368,7 +368,7 @@ defaults:
                     </picc-meter>
                     <figcaption>
                       <i class="fa average-arrow" data-meter="low-income-meter"></i>
-                      <span data-bind="average_cost">15%</span>
+                      <span data-bind="low_income_percent">XX%</span>
                     </figcaption>
                   </figure>
                 </div>


### PR DESCRIPTION
This PR will get the placeholder values caught up with the data for the elements that exist on the page, including:

- [x] fixing the rendering bug with the average salary meter
* "Costs" section:
  - [x] ~~Tuition and fees **$XX,XXX** placeholders~~
  - [x] Average net price by income bracket **$XX,XXX** placeholders
- [ ] "Students Who Have Defaulted on Loans" meter
- "Financial Aid & Debt" section:
  - [ ] "Average Total Debt" **$XX,XXX**
  - [ ] "Average Monthly Loan Payment" **$XX,XXX**
  - [ ] "Students Receiving Federal Aid" **XX%**
- [x] "Graduation Rate" meters
- [x] "Students Who Return After Their First Year" meter
- [x] "Average Salary After Leaving School" meter
- [ ] "Former Students Earning Less Than $25K" meter