### PR TITLE
Common directives

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -18,6 +18,7 @@ $dark-gray: #666666;
 $mid-gray: #e1e1e1;
 $light-gray: #eaeaea;
 $dark-blue: #0e365b;
+$darkest-blue: #040404;
 $mid-blue: #2b6091;
 $lighter-blue: tint($dark-blue, 6%);
 $sky-blue: #00adf2;

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -129,6 +129,11 @@
       picc-meter {
         height: 120px;
         width: 90%;
+
+        // don't show labels on small meters
+        .label {
+          visibility: hidden;
+        }
       }
     }
   }

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -149,6 +149,15 @@
     h1 {
       @include font-size(1.4);
       padding-top: 0;
+
+      a[href] {
+        color: $darkest-blue;
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
 
     @include respond-to(small-up) {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -130,6 +130,11 @@
     margin-top: $base-padding;
     padding-top: $base-padding;
     text-align: center;
+
+    // don't show meter labels for top-level stats
+    picc-meter .label {
+      visibility: hidden;
+    }
   }
 
   .school-fact_list {

--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -40,6 +40,15 @@ picc-meter {
       opacity: 0;
       transition: opacity .5s;
     }
+
+    .label {
+      height: 1em;
+      left: 100%;
+      line-height: 1em;
+      position: absolute;
+      margin: -.4em 0 0 8px;
+      // border: 1px dotted red;
+    }
   }
 
   &.above-average {

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -8,16 +8,6 @@
       {
 
         attachedCallback: {value: function() {
-          if (!this.__bar) {
-            var bar = this.__bar = this.appendChild(document.createElement('div'));
-            bar.className = CLASS_PREFIX + 'bar';
-          }
-
-          if (!this.__line) {
-            var line = this.__line = this.appendChild(document.createElement('div'));
-            line.className = CLASS_PREFIX + 'line';
-          }
-
           this.min = getAttr(this, 'min', 0);
           this.max = getAttr(this, 'max', 1);
           this.value = getAttr(this, 'value');
@@ -52,12 +42,12 @@
             return (scale(v) * 100).toFixed(1) + '%';
           };
 
-          var bar = this.__bar;
+          var bar = getBar(this);
           // prevent the bar from exceeding the height
           var value = Math.min(this.value, this.max);
           bar.style.setProperty('height', percent(value));
 
-          var line = this.__line;
+          var line = getLine(this);
 
           var average = this.average;
           var difference;
@@ -144,6 +134,26 @@
     return node.hasAttribute(attr)
       ? node.getAttribute(attr) || fallback
       : fallback;
+  }
+
+  function getBar(meter) {
+    var bar = meter.querySelector('.' + CLASS_PREFIX + 'bar');
+    if (!bar) {
+      bar = meter.appendChild(document.createElement('div'));
+      bar.className = CLASS_PREFIX + 'bar';
+    }
+    return bar;
+  }
+
+  function getLine(meter) {
+    var line = meter.querySelector('.' + CLASS_PREFIX + 'line');
+    if (!line) {
+      line = meter.appendChild(document.createElement('div'));
+      line.className = CLASS_PREFIX + 'line';
+      line.appendChild(document.createElement('span'))
+        .setAttribute('class', 'label');
+    }
+    return line;
   }
 
   function number(value, fallback) {

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -8,11 +8,15 @@
       {
 
         attachedCallback: {value: function() {
-          var bar = this.appendChild(document.createElement('div'));
-          bar.className = CLASS_PREFIX + 'bar';
+          if (!this.__bar) {
+            var bar = this.__bar = this.appendChild(document.createElement('div'));
+            bar.className = CLASS_PREFIX + 'bar';
+          }
 
-          var line = this.appendChild(document.createElement('div'));
-          line.className = CLASS_PREFIX + 'line';
+          if (!this.__line) {
+            var line = this.__line = this.appendChild(document.createElement('div'));
+            line.className = CLASS_PREFIX + 'line';
+          }
 
           this.min = getAttr(this, 'min', 0);
           this.max = getAttr(this, 'max', 1);
@@ -48,12 +52,12 @@
             return (scale(v) * 100).toFixed(1) + '%';
           };
 
-          var bar = this.querySelector('.' + CLASS_PREFIX + 'bar');
+          var bar = this.__bar;
           // prevent the bar from exceeding the height
           var value = Math.min(this.value, this.max);
           bar.style.setProperty('height', percent(value));
 
-          var line = this.querySelector('.' + CLASS_PREFIX + 'line');
+          var line = this.__line;
 
           var average = this.average;
           var difference;

--- a/js/picc.js
+++ b/js/picc.js
@@ -375,6 +375,7 @@
         '@max':     access.nationalStat('max', access.publicPrivate),
         '@average': access.nationalStat('median', access.publicPrivate),
         '@value':   access.netPrice,
+        label:      format.dollars(access.nationalStat('median', access.publicPrivate)),
         '@title':   debugMeterTitle
       },
 
@@ -389,18 +390,21 @@
       grad_rate_meter: {
         '@average': access.nationalStat('median', access.yearDesignation),
         '@value':   access.completionRate,
+        label:      format.percent(access.nationalStat('median', access.yearDesignation)),
         '@title':   debugMeterTitle
       },
 
       average_salary: format.dollars(access.medianEarnings),
       average_salary_meter: {
         '@value': access.medianEarnings,
+        label:    format.dollars(access.medianEarnings),
         '@title': debugMeterTitle
       },
 
       retention_rate_value: format.percent(picc.access.retentionRate),
       retention_rate_meter: {
-        '@value': picc.access.retentionRate,
+        '@value': access.retentionRate,
+        label:    format.percent(access.retentionRate),
         '@title': debugMeterTitle
       },
 

--- a/js/picc.js
+++ b/js/picc.js
@@ -5,6 +5,8 @@
 
   var picc = exports.picc = {};
 
+  picc.BASE_URL = '{{ site.baseurl }}';
+
   picc.API = (function() {
     var API = {
       url: '{{ site.api.baseurl }}',
@@ -315,5 +317,104 @@
   picc.nullify = function(value) {
     return value === 'NULL' ? null : value;
   };
+
+  /**
+   * namespace for school-related stuff
+   */
+  picc.school = {};
+
+  /**
+   * common directives for school templates
+   */
+  picc.school.directives = (function() {
+    var access = picc.access;
+    var format = picc.format;
+
+    var href = function(d) {
+      var name = d.name.replace(/\W+/g, '-');
+      return [
+        picc.BASE_URL, '/school/?',
+        d.id, '-', name
+      ].join('');
+    };
+
+    return {
+      title: {
+        link: {
+          text: 'name',
+          '@href': href
+        }
+      },
+
+      size_number:    format.number('size'),
+      control:        format.control('ownership'),
+      locale_name:    format.locale('locale'),
+      years:          format.preddeg('common_degree'),
+      size_category:  format.sizeCategory('size'),
+
+      // this is a direct accessor because some designations
+      // (e.g. `women_only`) are at the object root, rather than
+      // nested in `minority_serving`.
+      special_designation: access.specialDesignation,
+
+      SAT_avg: function(d) {
+        return picc.nullify(d.SAT_avg) || NA;
+      },
+
+      SAT_meter: {
+        // TODO
+      },
+
+      ACT_meter: {
+        // TODO
+      },
+
+      average_cost: format.dollars(access.netPrice),
+      average_cost_meter: {
+        '@max':     access.nationalStat('max', access.publicPrivate),
+        '@average': access.nationalStat('median', access.publicPrivate),
+        '@value':   access.netPrice,
+        '@title':   debugMeterTitle
+      },
+
+      // income level net price stats
+      net_price_income1: format.dollars(access.netPriceByIncomeLevel('0-30000')),
+      net_price_income2: format.dollars(access.netPriceByIncomeLevel('30001-48000')),
+      net_price_income3: format.dollars(access.netPriceByIncomeLevel('48001-75000')),
+      net_price_income4: format.dollars(access.netPriceByIncomeLevel('75001-110000')),
+      net_price_income5: format.dollars(access.netPriceByIncomeLevel('110001-plus')),
+
+      grad_rate: format.percent(access.completionRate),
+      grad_rate_meter: {
+        '@average': access.nationalStat('median', access.yearDesignation),
+        '@value':   access.completionRate,
+        '@title':   debugMeterTitle
+      },
+
+      average_salary: format.dollars(access.medianEarnings),
+      average_salary_meter: {
+        '@value': access.medianEarnings,
+        '@title': debugMeterTitle
+      },
+
+      retention_rate_value: format.percent(picc.access.retentionRate),
+      retention_rate_meter: {
+        '@value': picc.access.retentionRate,
+        '@title': debugMeterTitle
+      },
+
+      more_link: {
+        '@href': href
+      }
+    };
+
+    function debugMeterTitle(d) {
+      return [
+        'value: ', this.getAttribute('value'), '\n',
+        'median: ', this.getAttribute('average')
+      ].join('');
+    }
+
+  })();
 
 })(this);

--- a/js/picc.js
+++ b/js/picc.js
@@ -177,10 +177,11 @@
       // format.preddeg('deg')({deg: 2}) === '2-year'
       // format.preddeg('deg')({deg: 3}) === '4-year'
       preddeg: formatter(map({
+        '1': 'Certificate',
         '2': '2-year',
         '3': '4-year',
-        // '4': '???'
-      }, 'other degree designation')),
+        '4': 'Graduate'
+      }, NA)),
 
       sizeCategory: formatter(range([
         [0, 2000, 'Small'],

--- a/js/school.js
+++ b/js/school.js
@@ -1,6 +1,3 @@
----
-# // hey there
----
 (function(exports) {
 
   var id = getSchoolId();
@@ -10,63 +7,6 @@
   }
 
   var root = document.querySelector('#school');
-
-  var format = picc.format;
-  var access = picc.access;
-
-  var directives = {
-    size_number:    format.number('size'),
-    control:        format.control('ownership'),
-    locale_name:    format.locale('locale'),
-    years:          format.preddeg('common_degree'),
-    size_category:  format.sizeCategory('size'),
-
-    // this is a direct accessor because some designations
-    // (e.g. `women_only`) are at the object root, rather than
-    // nested in `minority_serving`.
-    special_designation: access.specialDesignation,
-
-    SAT_avg: function(d) {
-      return picc.nullify(d.SAT_avg) || '?';
-    },
-    SAT_meter: {
-      // TODO
-    },
-
-    average_cost: format.dollars(access.netPrice),
-    average_cost_meter: {
-      '@max':     access.nationalStat('max', access.publicPrivate),
-      '@average': access.nationalStat('median', access.publicPrivate),
-      '@value':   access.netPrice,
-      '@title':   debugMeterTitle
-    },
-
-    net_price_income1: format.dollars(access.netPriceByIncomeLevel('0-30000')),
-    net_price_income2: format.dollars(access.netPriceByIncomeLevel('30001-48000')),
-    net_price_income3: format.dollars(access.netPriceByIncomeLevel('48001-75000')),
-    net_price_income4: format.dollars(access.netPriceByIncomeLevel('75001-110000')),
-    net_price_income5: format.dollars(access.netPriceByIncomeLevel('110001-plus')),
-
-    grad_rate: format.percent(access.completionRate),
-    grad_rate_meter: {
-      '@average': access.nationalStat('median', access.yearDesignation),
-      '@value':   access.completionRate,
-      '@title':   debugMeterTitle
-    },
-
-    average_salary: format.dollars(access.medianEarnings),
-    average_salary_meter: {
-      '@value': access.medianEarnings,
-      '@title': debugMeterTitle
-    },
-
-    retention_rate_value: format.percent(picc.access.retentionRate),
-    retention_rate_meter: {
-      '@value': picc.access.retentionRate,
-      '@title': debugMeterTitle
-    }
-
-  };
 
   picc.API.getSchool(id, function(error, school) {
     if (error) {
@@ -97,6 +37,10 @@
     // this is necessary because tagalong only binds to
     // the first instance for each data or directive key
     var sections = root.querySelectorAll('.section-card_container-school');
+
+    // common school template directives
+    var directives = picc.school.directives;
+
     [root]
       .concat([].slice.call(sections))
       .forEach(function(node) {
@@ -175,13 +119,6 @@
     var target = container.querySelector('.error-message') || container;
     target.textContent = message;
     return target;
-  }
-
-  function debugMeterTitle(d) {
-    return [
-      'value: ', this.getAttribute('value'), '\n',
-      'median: ', this.getAttribute('average')
-    ].join('');
   }
 
 })(this);

--- a/js/search.js
+++ b/js/search.js
@@ -35,24 +35,13 @@
     console.time('[render] template');
     // render the basic DOM template for each school
     tagalong(resultsRoot, data, {
-      results_word: format.plural('total', 'Result')
+      results_word: format.plural('total', 'Result'),
+      results_total: format.number('total', '0')
     });
-
-    d3.select(resultsRoot)
-      .datum(data)
-      .select('[data-bind="total"]')
-        .text(format.number('total', '0'));
 
     var resultsList = resultsRoot.querySelector('.schools-list');
-    tagalong(resultsList, data.results, {
-      size_pretty: format.number('size'),
-      link: {
-        '@href': function(d) {
-          var name = d.name.replace(/\W+/g, '-');
-          return ['../school/?', d.id, '-', name].join('');
-        }
-      }
-    });
+    tagalong(resultsList, data.results, picc.school.directives);
+
     console.timeEnd('[render] template');
 
     console.time('[render] charts');

--- a/search/index.html
+++ b/search/index.html
@@ -37,7 +37,7 @@ body_scripts:
 
         <div class="container show-loaded">
           <h1>
-            <span class="results-count" data-bind="total">0</span>
+            <span data-bind="results_total">0</span>
             <span data-bind="results_word">Results</span>
             Based on Your Criteria
           </h1>
@@ -52,15 +52,14 @@ body_scripts:
 
           <!-- this element is the template for the results listing -->
           <div class="school results-card">
-            <h1 class="name">School Name</h1>
+            <h1 data-bind="title"><a class="link">School Name</a></h1>
             <ul class="school-info">
               <li class="location">
                 <span data-bind="city">City</span>,
                 <span data-bind="state">State</span>
-                (region <b data-bind="region">X</b>)
               </li>
               <li class="institution-category">
-                <span data-bind="category">category here</span>
+                <span data-bind="years">year category</span>
               </li>
               <li>
                 <span data-bind="size">x</span> undergraduate students
@@ -72,10 +71,10 @@ body_scripts:
                 <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
                 <picc-meter class="cost"
                   data-bind="average_cost_meter"
-                  data-max-public="{{ site.data.national_stats.average_price_public.max }}"
-                  data-max-private="{{ site.data.national_stats.average_price_private.max }}"
-                  data-median-public="{{ site.data.national_stats.average_price_public.median }}"
-                  data-median-private="{{ site.data.national_stats.average_price_private.median }}">
+                  data-max-public="{{ site.data.national_stats.net_price_public.max }}"
+                  data-max-private="{{ site.data.national_stats.net_price_private.max }}"
+                  data-median-public="{{ site.data.national_stats.net_price_public.median }}"
+                  data-median-private="{{ site.data.national_stats.net_price_private.median }}">
                 </picc-meter>
                 <figcaption>
                   <span data-bind="average_cost"></span>
@@ -110,7 +109,7 @@ body_scripts:
               </figure>
             </div>
 
-            <a class="link link-more">
+            <a class="link link-more" data-bind="more_link">
               View more details <i class="fa fa-chevron-right"></i>
             </a>
 


### PR DESCRIPTION
This PR moves all of the templating directives (the bits of logic that prep API data for display in the document) for schools into the common `picc.js` script so they can be used by both the search results and institution pages (and potentially other pages in the future). With all of the directives in place on the search results page, we can now see results like this:

![image](https://cloud.githubusercontent.com/assets/113896/8863567/b51ba866-314e-11e5-98ba-f40f8dc663ab.png)

It also fixes #142, a new bug with the meters being rendered in search results, and adds text for the 2-/4-year designations of primarily Certificate and Graduate degree-granting institutions, which relates to #81.