### PR TITLE
Fix special designations

### DIFF
--- a/js/picc.js
+++ b/js/picc.js
@@ -84,7 +84,9 @@
    * object.
    */
   var SPECIAL_DESIGNATIONS = {
-    aanipi:               'AANAPISI',
+    // TODO: rename 'aanapi' or 'aanapisi'
+    // per <http://www2.ed.gov/programs/aanapi/index.html>
+    aanipi:               'AANAPI',
     hispanic:             'Hispanic',
     historically_black:   'Historically Black',
     predominantly_black:  'Predominantly Black',

--- a/js/picc.js
+++ b/js/picc.js
@@ -295,7 +295,7 @@
     ) / size;
   };
 
-  picc.access.specialDesignation = function(d) {
+  picc.access.specialDesignations = function(d) {
     var designations = [];
 
     if (+d.women_only) {
@@ -312,7 +312,7 @@
       }
     }
 
-    return designations.join(', ');
+    return designations;
   };
 
   picc.nullify = function(value) {
@@ -356,7 +356,7 @@
       // this is a direct accessor because some designations
       // (e.g. `women_only`) are at the object root, rather than
       // nested in `minority_serving`.
-      special_designation: access.specialDesignation,
+      special_designations: access.specialDesignations,
 
       SAT_avg: function(d) {
         return picc.nullify(d.SAT_avg) || NA;

--- a/js/picc.js
+++ b/js/picc.js
@@ -84,7 +84,7 @@
    * object.
    */
   var SPECIAL_DESIGNATIONS = {
-    aanipi:               'Alaskan American/Native Indian/Pacific Islander',
+    aanipi:               'AANAPISI',
     hispanic:             'Hispanic',
     historically_black:   'Historically Black',
     predominantly_black:  'Predominantly Black',

--- a/school/index.html
+++ b/school/index.html
@@ -66,10 +66,8 @@ defaults:
             </li>
           </ul>
 
-          <ul class="school-special_designation">
-            <li class="special">Men Only</li>
-            <!-- <li class="special">Alaskan American/Native Indian/Pacific Islander</li> -->
-            <li class="special">Predominantly Black</li>
+          <ul class="school-special_designation" data-bind="special_designations">
+            <li class="special"></li>
           </ul>
 
           <!-- <h3 class="special" data-bind="special_designation">


### PR DESCRIPTION
This PR fixes the special designations on the school page so they're read from the data. The HTML does what it's supposed to, but the CSS has its quirks with long values.

All you, @meiqimichelle!