### PR TITLE
Above/below/about average states

### DIFF
--- a/_includes/earnings_meter_attributes.html
+++ b/_includes/earnings_meter_attributes.html
@@ -1,0 +1,4 @@
+  class="earnings"
+  data-bind="average_salary_meter"
+  max="150000"
+  average="25000"

--- a/_includes/graduation_meter_attributes.html
+++ b/_includes/graduation_meter_attributes.html
@@ -1,0 +1,5 @@
+  class="graduation"
+  data-bind="grad_rate_meter"
+  max="1"
+  data-median-four_year="{{ site.data.national_stats.completion_rate_4.median }}"
+  data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}"

--- a/_includes/net_price_meter_attributes.html
+++ b/_includes/net_price_meter_attributes.html
@@ -1,0 +1,7 @@
+  class="cost"
+  data-bind="average_cost_meter"
+  data-max-public="{{ site.data.national_stats.net_price_public.max }}"
+  data-max-private="{{ site.data.national_stats.net_price_private.max }}"
+  data-median-public="{{ site.data.national_stats.net_price_public.median }}"
+  data-median-private="{{ site.data.national_stats.net_price_private.median }}"
+

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -283,13 +283,13 @@
   padding-bottom: $base-padding;
 }
 
-.above-is-good .average.above_average,
-.below-is-good .average.below_average {
+.above_is_good .average.above_average,
+.below_is_good .average.below_average {
   color: $green;
 }
 
-.above-is-good .average.below_average,
-.below-is-good .average.above_average {
+.above_is_good .average.below_average,
+.below_is_good .average.above_average {
   color: $red;
 }
 

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -283,7 +283,21 @@
   padding-bottom: $base-padding;
 }
 
-// color the up arrows red
-.fa.above-average {
+.above-is-good .average-arrow.above-average,
+.below-is-good .average-arrow.below-average {
+  color: $green;
+}
+
+.above-is-good .average-arrow.below-average,
+.below-is-good .average-arrow.above-average {
   color: $red;
+}
+
+.average-arrow.about-average {
+  color: $mid-blue;
+}
+
+.average-display {
+  font-size: .5em;
+  font-weight: normal;
 }

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -283,21 +283,21 @@
   padding-bottom: $base-padding;
 }
 
-.above-is-good .average-arrow.above-average,
-.below-is-good .average-arrow.below-average {
+.above-is-good .average.above-average,
+.below-is-good .average.below-average {
   color: $green;
 }
 
-.above-is-good .average-arrow.below-average,
-.below-is-good .average-arrow.above-average {
+.above-is-good .average.below-average,
+.below-is-good .average.above-average {
   color: $red;
 }
 
-.average-arrow.about-average {
+.average.about-average {
   color: $mid-blue;
 }
 
-.average-display {
+.average-label {
   font-size: .5em;
   font-weight: normal;
 }

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -283,17 +283,17 @@
   padding-bottom: $base-padding;
 }
 
-.above-is-good .average.above-average,
-.below-is-good .average.below-average {
+.above-is-good .average.above_average,
+.below-is-good .average.below_average {
   color: $green;
 }
 
-.above-is-good .average.below-average,
-.below-is-good .average.above-average {
+.above-is-good .average.below_average,
+.below-is-good .average.above_average {
   color: $red;
 }
 
-.average.about-average {
+.average.about_average {
   color: $mid-blue;
 }
 

--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -51,7 +51,7 @@ picc-meter {
     }
   }
 
-  &.above-average {
+  &.above_average {
     .picc-meter-line:after {
       opacity: 1;
     }
@@ -63,7 +63,7 @@ picc-meter {
         background-color: $meter-color;
       }
 
-      &.above-average .picc-meter-line:after {
+      &.above_average .picc-meter-line:after {
         background-color: tint($meter-color, 75%);
       }
     }

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -55,9 +55,9 @@
           if (isNaN(average)) {
             line.style.setProperty('display', 'none');
             classify(this, {
-              'above-average': false,
-              'below-average': false,
-              'about-average': false
+              'above_average': false,
+              'below_average': false,
+              'about_average': false
             });
           } else {
             difference = value - average;
@@ -65,9 +65,9 @@
             line.style.setProperty('bottom', percent(this.average));
             var aboutThreshold = getAttr(this, 'about-threshold', .05) * (this.max - this.min);
             classify(this, {
-              'above-average': difference > 0,
-              'below-average': difference < 0,
-              'about-average': Math.abs(difference) <= aboutThreshold
+              'above_average': difference > 0,
+              'below_average': difference < 0,
+              'about_average': Math.abs(difference) <= aboutThreshold
             });
           }
 

--- a/js/picc.js
+++ b/js/picc.js
@@ -390,21 +390,27 @@
       grad_rate_meter: {
         '@average': access.nationalStat('median', access.yearDesignation),
         '@value':   access.completionRate,
-        label:      format.percent(access.nationalStat('median', access.yearDesignation)),
+        label:      format.percent(function() {
+          return this.getAttribute('average');
+        }),
         '@title':   debugMeterTitle
       },
 
       average_salary: format.dollars(access.medianEarnings),
       average_salary_meter: {
         '@value': access.medianEarnings,
-        label:    format.dollars(access.medianEarnings),
+        label:    format.dollars(function() {
+          return this.getAttribute('average');
+        }),
         '@title': debugMeterTitle
       },
 
       retention_rate_value: format.percent(picc.access.retentionRate),
       retention_rate_meter: {
         '@value': access.retentionRate,
-        label:    format.percent(access.retentionRate),
+        label:    format.percent(function() {
+          return this.getAttribute('average');
+        }),
         '@title': debugMeterTitle
       },
 

--- a/js/school.js
+++ b/js/school.js
@@ -8,6 +8,12 @@
 
   var root = document.querySelector('#school');
 
+  var averageLabels = {
+    'above': 'Above average',
+    'below': 'Lower than average',
+    'about': 'About average'
+  };
+
   picc.API.getSchool(id, function(error, school) {
     if (error) {
       return showError(error);
@@ -23,15 +29,20 @@
         var icon = d3.select(this);
         var meter = d3.select('#' + this.getAttribute('data-meter'))
           .on('update', function() {
-            var above = this.classList.contains('above-average');
+            var match = this.className.match(/\b(\w+)-average\b/);
+            var state = match ? match[1] : null;
+            console.log(this.className, '->', state);
             icon
-              .classed('above-average fa-arrow-up', above)
-              .classed('below-average fa-arrow-down', !above)
-              .attr('title', above
-                ? 'above average'
-                : 'below average');
-            // console.log('update:', this.className, above, icon.attr('class'));
+              .classed('above-average fa-arrow-up', state === 'above')
+              .classed('below-average fa-arrow-down', state === 'below')
+              .classed('about-average fa-check', state === 'about');
+
+            var text = averageLabels[state];
+            icon.attr('title', text);
+            display.text(text);
           });
+        var display = d3.select(this.parentNode)
+          .select('.average-display');
       });
 
     // this is necessary because tagalong only binds to

--- a/js/school.js
+++ b/js/school.js
@@ -31,7 +31,6 @@
           .on('update', function() {
             var match = this.className.match(/\b(\w+)-average\b/);
             var state = match ? match[1] : 'na';
-            console.log(this.className, '->', state);
             icon
               .classed('above-average fa-arrow-up', state === 'above')
               .classed('below-average fa-arrow-down', state === 'below')

--- a/js/school.js
+++ b/js/school.js
@@ -30,7 +30,7 @@
         var meter = d3.select('#' + this.getAttribute('data-meter'))
           .on('update', function() {
             var match = this.className.match(/\b(\w+)-average\b/);
-            var state = match ? match[1] : null;
+            var state = match ? match[1] : 'na';
             console.log(this.className, '->', state);
             icon
               .classed('above-average fa-arrow-up', state === 'above')
@@ -39,10 +39,14 @@
 
             var text = averageLabels[state];
             icon.attr('title', text);
-            display.text(text);
+            label
+              .classed('above-average', state === 'above')
+              .classed('below-average', state === 'below')
+              .classed('about-average', state === 'about')
+              .text(text);
           });
-        var display = d3.select(this.parentNode)
-          .select('.average-display');
+        var label = d3.select(this.parentNode)
+          .select('.average-label');
       });
 
     // this is necessary because tagalong only binds to

--- a/js/school.js
+++ b/js/school.js
@@ -29,19 +29,19 @@
         var icon = d3.select(this);
         var meter = d3.select('#' + this.getAttribute('data-meter'))
           .on('update', function() {
-            var match = this.className.match(/\b(\w+)-average\b/);
+            var match = this.className.match(/\b(\w+)_average\b/);
             var state = match ? match[1] : 'na';
             icon
-              .classed('above-average fa-arrow-up', state === 'above')
-              .classed('below-average fa-arrow-down', state === 'below')
-              .classed('about-average fa-check', state === 'about');
+              .classed('above_average fa-arrow-up', state === 'above')
+              .classed('below_average fa-arrow-down', state === 'below')
+              .classed('about_average fa-check', state === 'about');
 
             var text = averageLabels[state];
             icon.attr('title', text);
             label
-              .classed('above-average', state === 'above')
-              .classed('below-average', state === 'below')
-              .classed('about-average', state === 'about')
+              .classed('above_average', state === 'above')
+              .classed('below_average', state === 'below')
+              .classed('about_average', state === 'about')
               .text(text);
           });
         var label = d3.select(this.parentNode)

--- a/js/search.js
+++ b/js/search.js
@@ -44,22 +44,8 @@
 
     console.timeEnd('[render] template');
 
-    console.time('[render] charts');
-    // bind all of the data to elements in d3, then
-    // call renderCharts() on the selection
-    d3.select(resultsList)
-      .selectAll('.school')
-      .data(data.results)
-      .call(renderCharts);
-    console.timeEnd('[render] charts');
-
     console.timeEnd('[render]');
   });
-
-  function renderCharts(selection) {
-    selection.select('[data-bind="size"]')
-      .text(format.number('size'));
-  }
 
   function showError(error) {
     console.error('error:', error);

--- a/school/index.html
+++ b/school/index.html
@@ -313,6 +313,7 @@ defaults:
                     <figcaption>
                       <i class="fa average-arrow" data-meter="grad-meter"></i>
                       <span data-bind="grad_rate">60%</span>
+                      <div class="average-display"></div>
                     </figcaption>
                   </figure>
                 </div>
@@ -330,6 +331,7 @@ defaults:
                     <figcaption>
                       <i class="fa average-arrow" data-meter="retention-meter"></i>
                       <span data-bind="retention_rate_value">XX%</span>
+                      <div class="average-display"></div>
                     </figcaption>
                   </figure>
                 </div>

--- a/school/index.html
+++ b/school/index.html
@@ -155,8 +155,9 @@ defaults:
                       {{ average_cost_meter }}>
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-arrow" data-meter="cost-meter"></i>
+                      <i class="fa average average-arrow" data-meter="cost-meter"></i>
                       <span data-bind="average_cost"></span>
+                      <div class="average average-label"></div>
                     </figcaption>
                   </figure>
                   <!--
@@ -230,8 +231,9 @@ defaults:
                       average="{{ site.data.national_stats.default_rate.median }}">
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-arrow" data-meter="default-meter"></i>
+                      <i class="fa average average-arrow" data-meter="default-meter"></i>
                       <span data-bind="default_rate">XX%</span>
+                      <div class="average average-label"></div>
                     </figcaption>
                   </figure>
 
@@ -311,16 +313,16 @@ defaults:
                       {{ grad_rate_meter }}>
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-arrow" data-meter="grad-meter"></i>
+                      <i class="fa average average-arrow" data-meter="grad-meter"></i>
                       <span data-bind="grad_rate">60%</span>
-                      <div class="average-display"></div>
+                      <div class="average average-label"></div>
                     </figcaption>
                   </figure>
                 </div>
 
                 <div class="school-two_col-right centered">
                   <figure class="meter above-is-good">
-                    <h2 class="figure-heading">Students Who Return <br>Each Year</h2>
+                    <h2 class="figure-heading">Students Who<br>Return Each Year</h2>
                     <picc-meter id="retention-meter"
                       class="graduation"
                       data-bind="retention_rate_meter"
@@ -329,9 +331,9 @@ defaults:
                       average="{{ site.data.national_stats.retention_rate.median }}">
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-arrow" data-meter="retention-meter"></i>
+                      <i class="fa average average-arrow" data-meter="retention-meter"></i>
                       <span data-bind="retention_rate_value">XX%</span>
-                      <div class="average-display"></div>
+                      <div class="average average-label"></div>
                     </figcaption>
                   </figure>
                 </div>
@@ -360,6 +362,7 @@ defaults:
                     <figcaption>
                       <i class="fa average-cost" data-meter="salary-meter"></i>
                       <span data-bind="average_salary">$XX,XXX</span>
+                      <div class="average average-label"></div>
                     </figcaption>
                   </figure>
                 </div>
@@ -375,7 +378,7 @@ defaults:
                       average="{# TODO #}">
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-arrow" data-meter="low-income-meter"></i>
+                      <i class="fa average average-arrow" data-meter="low-income-meter"></i>
                       <span data-bind="low_income_percent">XX%</span>
                     </figcaption>
                   </figure>

--- a/school/index.html
+++ b/school/index.html
@@ -81,7 +81,7 @@ defaults:
         </div>
 
         <div id="key-stats" class="school-meters">
-          <figure class="meter">
+          <figure class="meter below-is-good">
             <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
             <picc-meter
             {% capture average_cost_meter %}
@@ -99,7 +99,7 @@ defaults:
             </figcaption>
           </figure>
 
-          <figure class="meter">
+          <figure class="meter above-is-good">
             <h2 class="figure-heading constrain_width">Graduation Rate</h2>
             <picc-meter
             {% capture grad_rate_meter %}
@@ -116,7 +116,7 @@ defaults:
             </figcaption>
           </figure>
 
-          <figure class="meter">
+          <figure class="meter above-is-good">
             <h2 class="figure-heading constrain_width">Average Salary</h2>
             <picc-meter
             {% capture average_salary_meter %}
@@ -149,7 +149,7 @@ defaults:
 
                 <div class="school-two_col-left centered">
 
-                  <figure class="meter">
+                  <figure class="meter below-is-good">
                     <h2 class="figure-heading">Average Net Price</h2>
                     <picc-meter id="cost-meter"
                       {{ average_cost_meter }}>
@@ -220,7 +220,7 @@ defaults:
 
                 <div class="school-two_col-left centered">
 
-                  <figure class="meter">
+                  <figure class="meter below-is-good">
                     <h2 class="figure-heading">Students Who Have Defaulted on Loans</h2>
                     <picc-meter id="default-meter"
                       class="default"
@@ -305,7 +305,7 @@ defaults:
               <div id="graduation-content" aria-hidden="true">
 
                 <div class="school-two_col-left centered">
-                  <figure class="meter">
+                  <figure class="meter above-is-good">
                     <h2 class="figure-heading constrain_width">Graduation Rate</h2>
                     <picc-meter id="grad-meter"
                       {{ grad_rate_meter }}>
@@ -318,7 +318,7 @@ defaults:
                 </div>
 
                 <div class="school-two_col-right centered">
-                  <figure class="meter">
+                  <figure class="meter above-is-good">
                     <h2 class="figure-heading">Students Who Return <br>Each Year</h2>
                     <picc-meter id="retention-meter"
                       class="graduation"
@@ -350,7 +350,7 @@ defaults:
 
               <div id="earnings-content" aria-hidden="true">
                 <div class="school-two_col-left centered">
-                  <figure class="meter">
+                  <figure class="meter above-is-good">
                     <h2 class="figure-heading">Average Salary <br>After Leaving School</h2>
                     <picc-meter id="salary-meter"
                       {{ average_salary_meter }}>
@@ -363,7 +363,7 @@ defaults:
                 </div>
 
                 <div class="school-two_col-right centered">
-                  <figure class="meter">
+                  <figure class="meter below-is-good">
                     <h2 class="figure-heading">Former Students <br>Earning Less Than $25K</h2>
                     <picc-meter class="earnings"
                       id="low-income-meter"

--- a/school/index.html
+++ b/school/index.html
@@ -81,7 +81,7 @@ defaults:
         </div>
 
         <div id="key-stats" class="school-meters">
-          <figure class="meter below-is-good">
+          <figure class="meter below_is_good">
             <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
             <picc-meter {% include net_price_meter_attributes.html %}>
             </picc-meter>
@@ -90,7 +90,7 @@ defaults:
             </figcaption>
           </figure>
 
-          <figure class="meter above-is-good">
+          <figure class="meter above_is_good">
             <h2 class="figure-heading constrain_width">Graduation Rate</h2>
             <picc-meter {% include graduation_meter_attributes.html %}>
             </picc-meter>
@@ -99,7 +99,7 @@ defaults:
             </figcaption>
           </figure>
 
-          <figure class="meter above-is-good">
+          <figure class="meter above_is_good">
             <h2 class="figure-heading constrain_width">Average Salary</h2>
             <picc-meter {% include earnings_meter_attributes.html %}>
             </picc-meter>
@@ -125,7 +125,7 @@ defaults:
 
                 <div class="school-two_col-left centered">
 
-                  <figure class="meter below-is-good">
+                  <figure class="meter below_is_good">
                     <h2 class="figure-heading">Average Net Price</h2>
                     <picc-meter id="cost-meter" {% include net_price_meter_attributes.html %}>
                     </picc-meter>
@@ -196,7 +196,7 @@ defaults:
 
                 <div class="school-two_col-left centered">
 
-                  <figure class="meter below-is-good">
+                  <figure class="meter below_is_good">
                     <h2 class="figure-heading">Students Who Have Defaulted on Loans</h2>
                     <picc-meter id="default-meter"
                       class="default"
@@ -282,7 +282,7 @@ defaults:
               <div id="graduation-content" aria-hidden="true">
 
                 <div class="school-two_col-left centered">
-                  <figure class="meter above-is-good">
+                  <figure class="meter above_is_good">
                     <h2 class="figure-heading constrain_width">Graduation Rate</h2>
                     <picc-meter id="grad-meter" {% include graduation_meter_attributes.html %}>
                     </picc-meter>
@@ -295,7 +295,7 @@ defaults:
                 </div>
 
                 <div class="school-two_col-right centered">
-                  <figure class="meter above-is-good">
+                  <figure class="meter above_is_good">
                     <h2 class="figure-heading">Students Who<br>Return Each Year</h2>
                     <picc-meter id="retention-meter"
                       class="graduation"
@@ -328,7 +328,7 @@ defaults:
 
               <div id="earnings-content" aria-hidden="true">
                 <div class="school-two_col-left centered">
-                  <figure class="meter above-is-good">
+                  <figure class="meter above_is_good">
                     <h2 class="figure-heading">Average Salary <br>After Leaving School</h2>
                     <picc-meter id="salary-meter" {% include earnings_meter_attributes.html %}>
                     </picc-meter>
@@ -341,7 +341,7 @@ defaults:
                 </div>
 
                 <div class="school-two_col-right centered">
-                  <figure class="meter below-is-good">
+                  <figure class="meter below_is_good">
                     <h2 class="figure-heading">Former Students <br>Earning Less Than $25K</h2>
                     <picc-meter class="earnings"
                       id="low-income-meter"

--- a/school/index.html
+++ b/school/index.html
@@ -83,16 +83,7 @@ defaults:
         <div id="key-stats" class="school-meters">
           <figure class="meter below-is-good">
             <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
-            <picc-meter
-            {% capture average_cost_meter %}
-              class="cost"
-              data-bind="average_cost_meter"
-              data-max-public="{{ site.data.national_stats.net_price_public.max }}"
-              data-max-private="{{ site.data.national_stats.net_price_private.max }}"
-              data-median-public="{{ site.data.national_stats.net_price_public.median }}"
-              data-median-private="{{ site.data.national_stats.net_price_private.median }}"
-            {% endcapture %}
-            {{ average_cost_meter }}>
+            <picc-meter {% include net_price_meter_attributes.html %}>
             </picc-meter>
             <figcaption>
               <span data-bind="average_cost">$XX,XXX</span>
@@ -101,15 +92,7 @@ defaults:
 
           <figure class="meter above-is-good">
             <h2 class="figure-heading constrain_width">Graduation Rate</h2>
-            <picc-meter
-            {% capture grad_rate_meter %}
-              class="graduation"
-              data-bind="grad_rate_meter"
-              max="1"
-              data-median-four_year="{{ site.data.national_stats.completion_rate_4.median }}"
-              data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}"
-            {% endcapture %}
-            {{ grad_rate_meter }}>
+            <picc-meter {% include graduation_meter_attributes.html %}>
             </picc-meter>
             <figcaption>
               <span data-bind="grad_rate">XX%</span>
@@ -118,14 +101,7 @@ defaults:
 
           <figure class="meter above-is-good">
             <h2 class="figure-heading constrain_width">Average Salary</h2>
-            <picc-meter
-            {% capture average_salary_meter %}
-              class="earnings"
-              data-bind="average_salary_meter"
-              {% if site.data.median_earnings.max %}max="{{ site.data.median_earnings.max }}"{% else %}max="{{ page.defaults.median_earnings.max }}"{% endif %}
-              average="{{ site.data.median_earnings.median }}"
-            {% endcapture %}
-            {{ average_salary_meter }}>
+            <picc-meter {% include earnings_meter_attributes.html %}>
             </picc-meter>
             <figcaption>
               <span data-bind="average_salary">$XX,XXX</span>
@@ -151,8 +127,7 @@ defaults:
 
                   <figure class="meter below-is-good">
                     <h2 class="figure-heading">Average Net Price</h2>
-                    <picc-meter id="cost-meter"
-                      {{ average_cost_meter }}>
+                    <picc-meter id="cost-meter" {% include net_price_meter_attributes.html %}>
                     </picc-meter>
                     <figcaption>
                       <i class="fa average average-arrow" data-meter="cost-meter"></i>
@@ -309,8 +284,7 @@ defaults:
                 <div class="school-two_col-left centered">
                   <figure class="meter above-is-good">
                     <h2 class="figure-heading constrain_width">Graduation Rate</h2>
-                    <picc-meter id="grad-meter"
-                      {{ grad_rate_meter }}>
+                    <picc-meter id="grad-meter" {% include graduation_meter_attributes.html %}>
                     </picc-meter>
                     <figcaption>
                       <i class="fa average average-arrow" data-meter="grad-meter"></i>
@@ -356,11 +330,10 @@ defaults:
                 <div class="school-two_col-left centered">
                   <figure class="meter above-is-good">
                     <h2 class="figure-heading">Average Salary <br>After Leaving School</h2>
-                    <picc-meter id="salary-meter"
-                      {{ average_salary_meter }}>
+                    <picc-meter id="salary-meter" {% include earnings_meter_attributes.html %}>
                     </picc-meter>
                     <figcaption>
-                      <i class="fa average-cost" data-meter="salary-meter"></i>
+                      <i class="fa average average-arrow" data-meter="salary-meter"></i>
                       <span data-bind="average_salary">$XX,XXX</span>
                       <div class="average average-label"></div>
                     </figcaption>

--- a/search/index.html
+++ b/search/index.html
@@ -62,19 +62,14 @@ body_scripts:
                 <span data-bind="years">year category</span>
               </li>
               <li>
-                <span data-bind="size">x</span> undergraduate students
+                <span data-bind="size_number">x</span> undergraduate students
               </li>
             </ul>
 
             <div id="key-stats" class="school-meters">
               <figure class="meter">
                 <h2 class="figure-heading constrain_width">Average Cost Per Year</h2>
-                <picc-meter class="cost"
-                  data-bind="average_cost_meter"
-                  data-max-public="{{ site.data.national_stats.net_price_public.max }}"
-                  data-max-private="{{ site.data.national_stats.net_price_private.max }}"
-                  data-median-public="{{ site.data.national_stats.net_price_public.median }}"
-                  data-median-private="{{ site.data.national_stats.net_price_private.median }}">
+                <picc-meter {% include net_price_meter_attributes.html %}>
                 </picc-meter>
                 <figcaption>
                   <span data-bind="average_cost"></span>
@@ -83,13 +78,7 @@ body_scripts:
 
               <figure class="meter">
                 <h2 class="figure-heading constrain_width">Graduation Rate</h2>
-                <picc-meter class="graduation"
-                  data-bind="grad_rate_meter"
-                  max="1"
-                  data-max-four_year="{{ site.data.national_stats.completion_rate_4.max }}"
-                  data-max-lt_four_year="{{ site.data.national_stats.completion_rate_l4.max }}"
-                  data-median-four_year="{{ site.data.national_stats.completion_rate_4.median }}"
-                  data-median-lt_four_year="{{ site.data.national_stats.completion_rate_l4.median }}">
+                <picc-meter {% include graduation_meter_attributes.html %}>
                 </picc-meter>
                 <figcaption>
                   <span data-bind="grad_rate"></span>
@@ -98,10 +87,7 @@ body_scripts:
 
               <figure class="meter">
                 <h2 class="figure-heading constrain_width">Average Salary</h2>
-                <picc-meter class="earnings"
-                  data-bind="average_salary_meter"
-                  max="{{ site.data.median_earnings.max }}"
-                  average="{{ site.data.median_earnings.median }}">
+                <picc-meter {% include earnings_meter_attributes.html %}>
                 </picc-meter>
                 <figcaption>
                   <span data-bind="average_salary"></span>


### PR DESCRIPTION
This PR adds a bunch of hooks for labeling and coloring the labels that sit below various meters to display whether their values are above, about, or below the average. Generally, they look like this:

![image](https://cloud.githubusercontent.com/assets/113896/8864885/3b83507c-315c-11e5-9fd4-fd0147988860.png) ![image](https://cloud.githubusercontent.com/assets/113896/8864888/47c1226a-315c-11e5-9ad4-c564dc1f2f80.png) ![image](https://cloud.githubusercontent.com/assets/113896/8864909/7b428e44-315c-11e5-8946-eea402d714c4.png)

@jjoteal, I couldn't quickly find a dash-like shape in [Font Awesome](http://fortawesome.github.io/Font-Awesome/cheatsheet/) for the "about average" labels, so I used a check mark. We can change that in a future issue.

Right now these are uniformly styled, but I've noticed that some meters have big, bold labels underneath them and others don't in Jessica's comps, but I'm hoping that's another detail that we can work out later.

Merging this will fix #151.