### PR TITLE
make authentication optional

### DIFF
--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -11,9 +11,9 @@ module Jekyll
       if ENV['API_KEY']
         site.config['api']['key'] = ENV['API_KEY']
       end
-      # puts "API: ------------------"
-      # puts site.config['api']
-      # puts "------------------"
+      puts "------------------"
+      puts "API: #{site.config['api']}"
+      puts "------------------"
     end
 
   end

--- a/config.ru
+++ b/config.ru
@@ -4,9 +4,12 @@ require 'vienna'
 use Rack::SslEnforcer
 
 ENV['AUTH'] ||= ""
-user, pass = ENV['AUTH'].split(',')
-use Rack::Auth::Basic do |username, password|
-  username == user and password == pass
+
+unless ENV['AUTH'].empty?
+  user, pass = ENV['AUTH'].split(',')
+  use Rack::Auth::Basic do |username, password|
+    username == user and password == pass
+  end
 end
 
 run Vienna::Application.new('_site')


### PR DESCRIPTION
when we deploy on Cloud Foundry, we should be able to have auth on or off