### PR TITLE
Stubs out data home

### DIFF
--- a/_includes/header-data.html
+++ b/_includes/header-data.html
@@ -22,7 +22,7 @@
           <a href="#"><li>Data Insights</li></a>
           <a href="#"><li>Explore the Data</li></a>
           <a href="#"><li>API Documentation</li></a>
-          <a href="{{ site.baseurl }}"><li>College Choice</li></a>
+          <a href="{{ site.baseurl }}/"><li>College Choice</li></a>
         </ul>
       </nav>
 

--- a/_includes/header-data.html
+++ b/_includes/header-data.html
@@ -1,0 +1,33 @@
+<header>
+
+  <div class="banner">
+
+    <div>
+
+      <a href="https://www.ed.gov/"><span class="ed-logo"></span> U.S. Department of Education</a>
+
+    </div>
+
+  </div>
+
+  <div class="title">
+
+    <div>
+
+      <h1><a href="{{ site.baseurl }}/data">Data Tool</a></h1>
+
+      <nav class="title-nav">
+        <ul>
+          <a href="{{ site.baseurl }}/data"><li>Home</li></a>
+          <a href="#"><li>Data Insights</li></a>
+          <a href="#"><li>Explore the Data</li></a>
+          <a href="#"><li>API Documentation</li></a>
+          <a href="{{ site.baseurl }}"><li>College Choice</li></a>
+        </ul>
+      </nav>
+
+    </div>
+
+  </div>
+
+</header>

--- a/_layouts/default-data.html
+++ b/_layouts/default-data.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+  <body>
+    {% include header-data.html %}
+    <main>
+      {{ content }}
+    </main>
+    {% include footer.html %}
+
+    {% for script in page.body_scripts %}
+    <script src="{{ site.baseurl }}/js/{{ script }}" data-src="{{ script }}"></script>
+    {% endfor %}
+  </body>
+</html>

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -27,6 +27,7 @@
 @import 'general/loadable';
 
 // Blocks
+@import 'blocks/data-home';
 @import 'blocks/footer';
 @import 'blocks/header';
 @import 'blocks/home';

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -14,9 +14,11 @@ $base-heading-line-height: 1.3;
 // Colors
 $white: #ffffff;
 $black: #040404;
+$light-putty: #f6f6f6;
 $dark-gray: #666666;
 $mid-gray: #e1e1e1;
 $light-gray: #eaeaea;
+$light-blue: #d5dfe8;
 $dark-blue: #0e365b;
 $darker-blue: #092236;
 $darkest-blue: #040404;

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -18,6 +18,7 @@ $dark-gray: #666666;
 $mid-gray: #e1e1e1;
 $light-gray: #eaeaea;
 $dark-blue: #0e365b;
+$darker-blue: #092236;
 $darkest-blue: #040404;
 $mid-blue: #2b6091;
 $lighter-blue: tint($dark-blue, 6%);
@@ -97,4 +98,3 @@ $splash-height: 37em;
 
 // Icons
 $icon-opacity: 0.4;
-

--- a/_sass/base/blocks/_data-home.scss
+++ b/_sass/base/blocks/_data-home.scss
@@ -1,0 +1,205 @@
+// Home
+//============================================
+
+.section-home-start {
+  @extend .centered;
+
+  background-color: $secondary-background-color;
+  color: $white;
+
+  @include respond-to(medium-up) {
+    border-radius: 0 0 $base-border-radius $base-border-radius;
+    padding-bottom: 14px;
+
+    h1 {
+      @include font-size($h1);
+      padding: 0;
+    }
+
+    .button-wizard {
+      height: 60px;
+      padding-top: 0.8em;
+    }
+
+    .section-home-start-group {
+      display: table;
+      width: 100%;
+    }
+
+    .section-home-start-group-left {
+      display: table-cell;
+      padding-right: 8px;
+    }
+
+    .section-home-start-group-right {
+      display: table-cell;
+      vertical-align: middle;
+    }
+  }
+}
+
+.section-home-facts {
+  @extend .centered;
+
+  li {
+    border-bottom: $thin-border-size solid $base-border-color;
+    display: inline-block;
+    margin: $base-padding $base-padding-extra;
+    padding-bottom: $base-padding;
+
+    @include respond-to(tiny-up) {
+      border-bottom: none;
+    }
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  strong {
+    @extend .fact_number;
+
+    &:nth-of-type(2) {
+      @include font-size($h1);
+      font-weight: normal;
+      line-height: 0.9;
+      padding-bottom: $base-padding-lite;
+    }
+  }
+
+}
+
+.section-home-numbers {
+  @extend .centered;
+  @extend .section-card_container;
+
+  background-color: $tertiary-background-color;
+  @include span-columns(12);
+
+  @include respond-to(medium-up) {
+    @include span-columns(6);
+  }
+
+  img {
+    @extend .new_line;
+    opacity: $icon-opacity;
+    margin-right: auto;
+    margin-left: auto;
+    width: 40px;
+  }
+
+  ul {
+    padding-bottom: ($base-padding + 0.5em);
+
+    @include respond-to(tiny-up) {
+      text-align: left;
+    }
+
+    li {
+      padding: ($base-padding-lite + 0.1em) $base-padding-extra ($base-padding / 1.5);
+      border-bottom: $thin-border-size solid $base-border-color;
+
+      &:first-of-type {
+        border-top: $thin-border-size solid $base-border-color;
+      }
+    }
+  }
+
+  @include respond-to(tiny-up) {
+    .section-home-numbers-group {
+      display: table;
+      width: 100%;
+    }
+
+    .section-home-numbers-group-left {
+      display: table-cell;
+      padding-right: 8px;
+    }
+
+    .section-home-numbers-group-right {
+      display: table-cell;
+      vertical-align: middle;
+    }
+  }
+}
+
+.section-home-paying {
+  @extend .centered;
+  @extend .section-card_container;
+  @include span-columns(12);
+  padding-top: 0;
+
+  > div > div {
+    margin-top: 0;
+  }
+
+  .section-home-paying-content {
+    padding: $base-padding $base-padding-large $base-padding-large $base-padding-large;
+    text-align: left;
+
+    p {
+      padding-bottom: $base-padding-lite;
+    }
+  }
+
+  @include respond-to(medium-up) {
+    @include span-columns(6);
+    padding-top: $base-padding;
+
+    > div > div {
+      margin-top: $base-padding;
+    }
+  }
+}
+
+.section-home-decision {
+  @extend .centered;
+
+  background-color: $quaternary-background-color;
+  color: $white;
+  padding-right: 0;
+  padding-left: 0;
+
+  h1 {
+    @extend .light_on_dark;
+    padding-right: $base-padding;
+    padding-bottom: $base-padding;
+    padding-left: $base-padding;
+
+    @include respond-to(tiny-up) {
+      padding-right: ($base-padding * 2.2);
+      padding-left: ($base-padding * 2.2);
+    }
+  }
+
+  video {
+    background-color: $mid-gray;
+    height: auto;
+    width: 100%;
+
+    @include respond-to(medium-up) {
+      width: 400px;
+    }
+  }
+
+  figcaption {
+
+    h1 {
+      @extend .h2;
+      padding-bottom: 0;
+    }
+  }
+}
+
+.home-splash {
+  background: url(../img/unsplash_placeholder.jpg) center center no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
+  height: $splash-height;
+  //TODO add query that doesn't load image at small sizes
+  //right now it is just covered, but still exists
+}
+
+.home-bg-gray {
+  background-color: $tertiary-background-color;
+}

--- a/_sass/base/blocks/_data-home.scss
+++ b/_sass/base/blocks/_data-home.scss
@@ -1,205 +1,55 @@
-// Home
-//============================================
+// Data Tool
+//=============================
 
-.section-home-start {
-  @extend .centered;
+.data-home-intro {
+  background: $light-putty;
 
-  background-color: $secondary-background-color;
-  color: $white;
-
-  @include respond-to(medium-up) {
-    border-radius: 0 0 $base-border-radius $base-border-radius;
-    padding-bottom: 14px;
-
-    h1 {
-      @include font-size($h1);
-      padding: 0;
-    }
-
-    .button-wizard {
-      height: 60px;
-      padding-top: 0.8em;
-    }
-
-    .section-home-start-group {
-      display: table;
-      width: 100%;
-    }
-
-    .section-home-start-group-left {
-      display: table-cell;
-      padding-right: 8px;
-    }
-
-    .section-home-start-group-right {
-      display: table-cell;
-      vertical-align: middle;
-    }
-  }
-}
-
-.section-home-facts {
-  @extend .centered;
-
-  li {
-    border-bottom: $thin-border-size solid $base-border-color;
-    display: inline-block;
-    margin: $base-padding $base-padding-extra;
-    padding-bottom: $base-padding;
-
-    @include respond-to(tiny-up) {
-      border-bottom: none;
-    }
-
-    &:last-of-type {
-      border-bottom: none;
-    }
-  }
-
-  strong {
-    @extend .fact_number;
-
-    &:nth-of-type(2) {
-      @include font-size($h1);
-      font-weight: normal;
-      line-height: 0.9;
-      padding-bottom: $base-padding-lite;
-    }
-  }
-
-}
-
-.section-home-numbers {
-  @extend .centered;
-  @extend .section-card_container;
-
-  background-color: $tertiary-background-color;
-  @include span-columns(12);
-
-  @include respond-to(medium-up) {
-    @include span-columns(6);
-  }
-
-  img {
-    @extend .new_line;
-    opacity: $icon-opacity;
-    margin-right: auto;
-    margin-left: auto;
-    width: 40px;
-  }
-
-  ul {
-    padding-bottom: ($base-padding + 0.5em);
-
-    @include respond-to(tiny-up) {
-      text-align: left;
-    }
-
-    li {
-      padding: ($base-padding-lite + 0.1em) $base-padding-extra ($base-padding / 1.5);
-      border-bottom: $thin-border-size solid $base-border-color;
-
-      &:first-of-type {
-        border-top: $thin-border-size solid $base-border-color;
-      }
-    }
-  }
-
-  @include respond-to(tiny-up) {
-    .section-home-numbers-group {
-      display: table;
-      width: 100%;
-    }
-
-    .section-home-numbers-group-left {
-      display: table-cell;
-      padding-right: 8px;
-    }
-
-    .section-home-numbers-group-right {
-      display: table-cell;
-      vertical-align: middle;
-    }
-  }
-}
-
-.section-home-paying {
-  @extend .centered;
-  @extend .section-card_container;
-  @include span-columns(12);
-  padding-top: 0;
-
-  > div > div {
-    margin-top: 0;
-  }
-
-  .section-home-paying-content {
-    padding: $base-padding $base-padding-large $base-padding-large $base-padding-large;
-    text-align: left;
-
-    p {
-      padding-bottom: $base-padding-lite;
-    }
-  }
-
-  @include respond-to(medium-up) {
-    @include span-columns(6);
-    padding-top: $base-padding;
-
-    > div > div {
-      margin-top: $base-padding;
-    }
-  }
-}
-
-.section-home-decision {
-  @extend .centered;
-
-  background-color: $quaternary-background-color;
-  color: $white;
-  padding-right: 0;
-  padding-left: 0;
-
-  h1 {
-    @extend .light_on_dark;
-    padding-right: $base-padding;
-    padding-bottom: $base-padding;
-    padding-left: $base-padding;
-
-    @include respond-to(tiny-up) {
-      padding-right: ($base-padding * 2.2);
-      padding-left: ($base-padding * 2.2);
-    }
-  }
-
-  video {
-    background-color: $mid-gray;
-    height: auto;
-    width: 100%;
+  h3 {
+    @include font-size($h5);
+    font-weight: 800;
+    letter-spacing: em(2.5);
+    text-transform: uppercase;
 
     @include respond-to(medium-up) {
-      width: 400px;
+        padding-top: 0;
     }
   }
 
-  figcaption {
+  p {
+    padding-right: $base-padding;
+  }
 
-    h1 {
-      @extend .h2;
-      padding-bottom: 0;
+  ul li {
+    @include font-size(0.8);
+    color: $mid-blue;
+    display: inline-block;
+    padding-top: $base-padding-lite;
+    padding-right: $base-padding-lite;
+
+    i {
+      @include font-size(1);
+      color: $sky-blue;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
     }
   }
 }
 
-.home-splash {
-  background: url(../img/unsplash_placeholder.jpg) center center no-repeat;
-  background-attachment: fixed;
-  background-size: cover;
-  height: $splash-height;
-  //TODO add query that doesn't load image at small sizes
-  //right now it is just covered, but still exists
+.data-home-intro-col-left {
+  @include span-columns(12);
+
+  @include respond-to(medium-up) {
+    @include span-columns(8);
+  }
 }
 
-.home-bg-gray {
-  background-color: $tertiary-background-color;
+.data-home-intro-col-right {
+  @include span-columns(12);
+
+  @include respond-to(medium-up) {
+    @include span-columns(4);
+  }
 }

--- a/_sass/base/blocks/_header.scss
+++ b/_sass/base/blocks/_header.scss
@@ -14,7 +14,7 @@ header {
   > div {
     @include padded-container();
     position: relative;
-  } 
+  }
 
   a {
     @include font-size(0.70);
@@ -55,12 +55,42 @@ header {
 
   h1 {
     @extend .title_heading;
+    float: left;
     font-weight: 400;
     line-height: 1;
+
     @include respond-to(tiny-up) {
       line-height: 0.7;
     }
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+// Data tool
+//=========================================
+
+.title-nav {
+
+  ul {
+    float: right;
+
+    li {
+      display: inline-block;
+      height: 59px;
+      @include respond-to(tiny-up) {
+        height: 76px;
+      }
+      font-weight: 200;
+
+      padding-top: 2em; //TODO remove padding from typography, and then remove here
+      padding-left: $base-padding;
+      padding-right: $base-padding;
+
+      &:hover,
+      &:focus {
+        background: $darker-blue;
+      }
+    }
   }
 }

--- a/_sass/base/blocks/_header.scss
+++ b/_sass/base/blocks/_header.scss
@@ -45,9 +45,6 @@ header {
 .title {
   background: $mid-blue;
   height: 59px;
-  @include respond-to(tiny-up) {
-      height: 76px;
-    }
 
   > div {
     @include padded-container();
@@ -64,6 +61,10 @@ header {
     }
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+  
+  @include respond-to(tiny-up) {
+    height: 76px;
   }
 }
 

--- a/data/index.html
+++ b/data/index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: default-data
 ---
 
 
@@ -43,7 +43,7 @@ layout: default
       <ul>
         {% for i in (1..3) %}
         <li>
-          College graduates earn 
+          College graduates earn
           <strong>85%</strong> <strong>more</strong>
           than those with just a <br>high school diploma
 

--- a/data/index.html
+++ b/data/index.html
@@ -2,124 +2,53 @@
 layout: default-data
 ---
 
+<div class="data-home-intro">
 
-<!-- background image -->
-<div class="home-splash"></div>
+  <section class="container section">
 
-<!-- search and -->
-<!-- where to start -->
-<section class="search_form">
+    <div class="data-home-intro-col-left">
 
-  {% include search-form.html %}
-
-  <section class="section section-home-start">
-
-    <div class="container section-home-start-group">
-
-      <h1 class="light_on_dark section-home-start-group-left">Not Sure Where to Start?</h1>
-
-      <button class="button-wizard section-home-start-group-right">
-        Help me find schools <br>best suited to me
-      </button>
+      <p>Welcome, mission statement, why this is important, join the conversation. Lorem ipsum dolor sed lacus id ligula hendrerit semper sed vitae risus.</p>
 
     </div>
 
-  </section>
+    <aside class="data-home-intro-col-right">
 
-</section>
-
-<!-- by the numbers -->
-<div>
-  <section class="section section-home-facts">
-
-    <div class="container">
-
-      <h1>By the Numbers</h1>
-
-      <a class="link-more">
-        More Key Facts <i class="fa fa-chevron-right"></i>
-      </a>
+      <h3>Join the Conversation</h3>
 
       <ul>
-        {% for i in (1..3) %}
-        <li>
-          College graduates earn
-          <strong>85%</strong> <strong>more</strong>
-          than those with just a <br>high school diploma
-
-          <!-- <div class="share">
-            <a>Facebook</a>
-            <a>Twitter</a>
-          </div> -->
-        </li>
-        {% endfor %}
+        <a href="#"><li><i class="fa fa-twitter"></i> @openEd on Twitter</li></a>
+        <a href="#"><li><i class="fa fa-stack-exchange"></i> StackExchange</li></a>
       </ul>
 
-    </div>
+    </aside>
 
   </section>
+
 </div>
 
-<!-- check out these schools -->
-<!-- and paying for college -->
-<div class="home-bg-gray">
+
+<div class="container">
+
+  <section class="section">
+
+    <h2>Data Insights</h2>
+
+    <p>Welcome, mission statement, why this is important, join the conversation. Lorem ipsum dolor sed lacus id ligula hendrerit semper sed vitae risus.</p>
+
+  </section>
+
+</div>
+
+<div style="background:#D5DFE8;">
 
   <div class="container">
 
-    <section class="section section-home-numbers">
+    <section class="section">
 
-      <div>
+      <h2>The Data at a Glance</h2>
 
-        <div>
-
-          <h1>Check Out These Schools</h1>
-
-          <ul class="section-home-numbers-group">
-            <li>
-              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-              <div class="section-home-numbers-group-right">10 schools that graduate <strong>90% of their students within 4 years</strong></div>
-            </li>
-            <li>
-              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-              <div class="section-home-numbers-group-right">25 schools that graduate students who earn the <strong>highest salaries 10 years after graduation</strong></div>
-            </li>
-            <li>
-              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-              <div class="section-home-numbers-group-right">25 community colleges with the <strong>highest number of students who transfer to 4-year institutions</strong></div>
-            </li>
-            <li>
-              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
-              <div class="section-home-numbers-group-right">25 community colleges with the <strong>highest number of students who transfer to 4-year institutions</strong></div>
-            </li>
-          </ul>
-
-        </div>
-
-      </div>
-
-    </section>
-
-    <section class="section section-home-paying">
-
-      <div>
-
-        <div>
-
-          <h1>Paying for College</h1>
-
-          <img src="{{ site.baseurl }}/img/cfpb-logo.png" alt="consumer finance protection bureau">
-
-          <div class="section-home-paying-content">
-
-            <p>Get help to make informed financial decisions about how to pay for college. Start by comparing financial aid offers or understanding student loan repayment options.</p>
-
-            <a href="http://www.consumerfinance.gov/paying-for-college/" class="link-more">Go to the consumer finance protection bureau <i class="fa fa-chevron-right"></i></a>
-
-          </div>
-
-        </div>
-
-      </div>
+      <p>Welcome, mission statement, why this is important, join the conversation. Lorem ipsum dolor sed lacus id ligula hendrerit semper sed vitae risus.</p>
 
     </section>
 
@@ -127,20 +56,30 @@ layout: default-data
 
 </div>
 
-<!-- how I'm deciding -->
-<div>
-  <section class="section section-home-decision">
+<div class="container">
 
-    <h1>How I'm Making My Decision About College</h1>
+  <section class="section">
 
-    <figure>
-      <video></video>
-      <figcaption>
-        <h1>Karissa S.</h1>
-        <p>17, High School Senior<br/>
-        Hutchinson, MN</p>
-      </figcaption>
-    </figure>
+    <h2>Download the Data</h2>
+
+    <p>Welcome, mission statement, why this is important, join the conversation. Lorem ipsum dolor sed lacus id ligula hendrerit semper sed vitae risus.</p>
 
   </section>
+
+</div>
+
+<div style="background:#0e365b; color: white;">
+
+  <div class="container">
+
+    <section class="section">
+
+      <h2>See the Data in Action</h2>
+
+      <p>Welcome, mission statement, why this is important, join the conversation. Lorem ipsum dolor sed lacus id ligula hendrerit semper sed vitae risus.</p>
+
+    </section>
+
+  </div>
+
 </div>

--- a/data/index.html
+++ b/data/index.html
@@ -1,0 +1,146 @@
+---
+layout: default
+---
+
+
+<!-- background image -->
+<div class="home-splash"></div>
+
+<!-- search and -->
+<!-- where to start -->
+<section class="search_form">
+
+  {% include search-form.html %}
+
+  <section class="section section-home-start">
+
+    <div class="container section-home-start-group">
+
+      <h1 class="light_on_dark section-home-start-group-left">Not Sure Where to Start?</h1>
+
+      <button class="button-wizard section-home-start-group-right">
+        Help me find schools <br>best suited to me
+      </button>
+
+    </div>
+
+  </section>
+
+</section>
+
+<!-- by the numbers -->
+<div>
+  <section class="section section-home-facts">
+
+    <div class="container">
+
+      <h1>By the Numbers</h1>
+
+      <a class="link-more">
+        More Key Facts <i class="fa fa-chevron-right"></i>
+      </a>
+
+      <ul>
+        {% for i in (1..3) %}
+        <li>
+          College graduates earn 
+          <strong>85%</strong> <strong>more</strong>
+          than those with just a <br>high school diploma
+
+          <!-- <div class="share">
+            <a>Facebook</a>
+            <a>Twitter</a>
+          </div> -->
+        </li>
+        {% endfor %}
+      </ul>
+
+    </div>
+
+  </section>
+</div>
+
+<!-- check out these schools -->
+<!-- and paying for college -->
+<div class="home-bg-gray">
+
+  <div class="container">
+
+    <section class="section section-home-numbers">
+
+      <div>
+
+        <div>
+
+          <h1>Check Out These Schools</h1>
+
+          <ul class="section-home-numbers-group">
+            <li>
+              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
+              <div class="section-home-numbers-group-right">10 schools that graduate <strong>90% of their students within 4 years</strong></div>
+            </li>
+            <li>
+              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
+              <div class="section-home-numbers-group-right">25 schools that graduate students who earn the <strong>highest salaries 10 years after graduation</strong></div>
+            </li>
+            <li>
+              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
+              <div class="section-home-numbers-group-right">25 community colleges with the <strong>highest number of students who transfer to 4-year institutions</strong></div>
+            </li>
+            <li>
+              <div class="section-home-numbers-group-left"><img src="{{ site.baseurl }}/img/education.svg" alt="Education"></div>
+              <div class="section-home-numbers-group-right">25 community colleges with the <strong>highest number of students who transfer to 4-year institutions</strong></div>
+            </li>
+          </ul>
+
+        </div>
+
+      </div>
+
+    </section>
+
+    <section class="section section-home-paying">
+
+      <div>
+
+        <div>
+
+          <h1>Paying for College</h1>
+
+          <img src="{{ site.baseurl }}/img/cfpb-logo.png" alt="consumer finance protection bureau">
+
+          <div class="section-home-paying-content">
+
+            <p>Get help to make informed financial decisions about how to pay for college. Start by comparing financial aid offers or understanding student loan repayment options.</p>
+
+            <a href="http://www.consumerfinance.gov/paying-for-college/" class="link-more">Go to the consumer finance protection bureau <i class="fa fa-chevron-right"></i></a>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    </section>
+
+  </div>
+
+</div>
+
+<!-- how I'm deciding -->
+<div>
+  <section class="section section-home-decision">
+
+    <h1>How I'm Making My Decision About College</h1>
+
+    <figure>
+      <video></video>
+      <figcaption>
+        <h1>Karissa S.</h1>
+        <p>17, High School Senior<br/>
+        Hutchinson, MN</p>
+      </figcaption>
+    </figure>
+
+  </section>
+</div>


### PR DESCRIPTION
This PR stubs out the data tool homepage and also adds desktop implementations for the title bar/nav and the first section of the page (intro). This addresses #263 and #143.

It also gets at #264 out of priority order, but it was easy to add that one in while I was in that section of the page.

![screen shot 2015-07-30 at 10 28 58 pm](https://cloud.githubusercontent.com/assets/4827522/9001296/68fa48cc-370a-11e5-8c57-b714a8f7f554.png)
