### PR TITLE
Fixes school accordions

### DIFF
--- a/js/school.js
+++ b/js/school.js
@@ -130,7 +130,7 @@
     var id = location.hash.substr(1);
     var found = false;
     picc.ui.expandAccordions(function() {
-      return this.id === id;
+      return this.id && this.id === id;
     })
     .each(function() {
       found = this;

--- a/school/index.html
+++ b/school/index.html
@@ -469,7 +469,7 @@ body_scripts:
         </div>
 
         <div class="section-card_container-school">
-          <aria-accordion class="school-two_col">
+          <aria-accordion id="selectivity" class="school-two_col">
             <div>
               <h1 class="search_category">
                 <a aria-expanded="false" aria-controls="selectivity-content">


### PR DESCRIPTION
There was an issue with the "Selectivity" section not having an id, which, combined with the logic for expanding sections by id in the hash made that section expand by default. This fixes both problems.