### PR TITLE
Multi-state search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ scripts:
   - components/aria-accordion.js
   - components/picc-meter.js
   - components/picc-range.js
+  - components/multi-select.js
   - picc.js
 
 stylesheets:

--- a/_data/states.csv
+++ b/_data/states.csv
@@ -6,7 +6,7 @@ AZ,Arizona
 CA,California
 CO,Colorado
 CT,Connecticut
-DC,District Of Columbia
+DC,District of Columbia
 DE,Delaware
 FL,Florida
 GA,Georgia

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -18,12 +18,12 @@
 
       <legend>Filters</legend>
       <h1 class="search_category">
-        <a aria-expanded="true" aria-controls="filters-content">
+        <a aria-expanded="false" aria-controls="filters-content">
           Filters
         </a>
       </h1>
 
-      <div id="filters-content" aria-hidden="false" class="accordion-div">
+      <div id="filters-content" aria-hidden="true" class="accordion-div">
 
         <div class="filter_section">
           <h2>Cost Per Year</h2>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -62,7 +62,7 @@
 
   <fieldset>
 
-    <aria-accordion id="name-accordion" class="container">
+    <aria-accordion id="school-name" class="container">
 
       <legend>Name</legend>
       <h1 class="search_category">
@@ -82,7 +82,7 @@
 
   <fieldset>
 
-    <aria-accordion id="location-accordion" class="container">
+    <aria-accordion id="school-location" class="container">
 
       <legend>Location</legend>
       <h1 class="search_category">
@@ -147,7 +147,7 @@
 
   <fieldset>
 
-    <aria-accordion id="degree-accordion" class="container">
+    <aria-accordion id="school-degree" class="container">
 
       <legend>Major/Degree</legend>
       <h1 class="search_category">
@@ -175,7 +175,7 @@
 
   <fieldset>
 
-    <aria-accordion id="size-accordion" class="container">
+    <aria-accordion id="school-size" class="container">
 
       <legend>Size</legend>
       <h1 class="search_category">

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -97,36 +97,28 @@
 
         <div class="input-add group_inline">
 
-          <label for="select-state" class="group_inline-left">
+          <label for="select-state">
             Select one or more states
           </label>
 
-          <combo-box>
-            <input type="text"
-              role="combobox"
-              aria-label="Select one or more states"
-              aria-owns="state-options">
-            <ol id="state-options"
-              role="listbox"
-              aria-multiselectable="true">
-              {% for state in site.data.states|sort('name') %}
-              <li role="option" id="state-option-{{ state.abbr }}">
-                <label tabindex="0">
-                  <input type="checkbox" name="state" value="{{ state.abbr }}">
-                  <span class="combo-box_label">{{ state.name }}</span>
-                </label>
-              </li>
-              {% endfor %}
-            </ol>
-          </combo-box>
-
-          <!--
-          <div class="group_inline-right">
-            <button class="button button-add" data-input="state">
-              Add State
-            </button>
-          </div>
-          -->
+          <multi-select>
+            <div class="u-group_inline u-group_inline-left">
+              <select name="state">
+                <option value=""></option>
+                {% for state in site.data.states|sort('name') %}
+                <option value="{{ state.abbr }}">{{ state.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="u-group_inline u-group_inline-right u-nowrap">
+              <button class="button button-add">
+                Add State
+              </button>
+              <button class="button button-remove">
+                &times;
+              </button>
+            </div>
+          </multi-select>
 
         </div>
 

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -109,7 +109,7 @@
               aria-multiselectable="true">
               {% for state in site.data.states|sort('name') %}
               <li role="option" id="state-option-{{ state.abbr }}">
-                <label>
+                <label tabindex="0">
                   <input type="checkbox" name="state" value="{{ state.abbr }}">
                   <span class="combo-box_label">{{ state.name }}</span>
                 </label>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -100,10 +100,15 @@
           </label>
 
           <combo-box>
-            <input type="text" class="combo-box_search">
-            <ol class="combo-box_options">
+            <input type="text"
+              role="combobox"
+              aria-label="Select one or more states"
+              aria-owns="state-options">
+            <ol id="state-options"
+              role="listbox"
+              aria-multiselectable="true">
               {% for state in site.data.states|sort('name') %}
-              <li class="combo-box_option">
+              <li role="option" id="state-option-{{ state.abbr }}">
                 <label>
                   <input type="checkbox" name="state" value="{{ state.abbr }}">
                   <span class="combo-box_label">{{ state.name }}</span>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -1,4 +1,6 @@
-<form id="search-form" is="search-form" action="{{ site.baseurl }}/search/" method="GET">
+<form id="search-form" is="search-form"
+  autocomplete="false"
+  action="{{ site.baseurl }}/search/" method="GET">
   {% capture common_input_attributes %}autocomplete="off" autocorrect="off" autocapitalize="off"{% endcapture %}
 
   <div class="container search-form-intro">

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -96,7 +96,7 @@
         <div class="input-add group_inline">
 
           <label for="select-state" class="group_inline-left">Select a state
-            <select id="select-state" name="state">
+            <select id="select-state" name="state" multiple="">
               <option value=""></option>
               {% for state in site.data.states|sort('name') %}
               <option value="{{ state.abbr }}">{{ state.name }}</option>
@@ -105,11 +105,13 @@
             </select>
           </label>
 
+          <!--
           <div class="group_inline-right">
             <button class="button button-add" data-input="state">
               Add State
             </button>
           </div>
+          -->
 
         </div>
 

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -95,15 +95,23 @@
 
         <div class="input-add group_inline">
 
-          <label for="select-state" class="group_inline-left">Select a state
-            <select id="select-state" name="state" multiple="">
-              <option value=""></option>
-              {% for state in site.data.states|sort('name') %}
-              <option value="{{ state.abbr }}">{{ state.name }}</option>
-              {% endfor %}
-              <i class="fa fa-chevron-down"></i>
-            </select>
+          <label for="select-state" class="group_inline-left">
+            Select one or more states
           </label>
+
+          <combo-box>
+            <input type="text" class="combo-box_search">
+            <ol class="combo-box_options">
+              {% for state in site.data.states|sort('name') %}
+              <li class="combo-box_option">
+                <label>
+                  <input type="checkbox" name="state" value="{{ state.abbr }}">
+                  <span class="combo-box_label">{{ state.name }}</span>
+                </label>
+              </li>
+              {% endfor %}
+            </ol>
+          </combo-box>
 
           <!--
           <div class="group_inline-right">

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -29,7 +29,7 @@
 @import 'components/forms';
 @import 'components/loadable';
 @import 'components/aria-accordion';
-@import 'components/combo-box';
+// @import 'components/combo-box';
 @import 'components/picc-meter';
 @import 'components/picc-range';
 @import 'components/picc-slider';

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -29,6 +29,7 @@
 @import 'components/forms';
 @import 'components/loadable';
 @import 'components/aria-accordion';
+@import 'components/combo-box';
 @import 'components/picc-meter';
 @import 'components/picc-range';
 @import 'components/picc-slider';

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -33,6 +33,7 @@
 @import 'components/picc-meter';
 @import 'components/picc-range';
 @import 'components/picc-slider';
+@import 'components/multi-select';
 @import 'components/sections';
 
 // Blocks

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -22,6 +22,10 @@
   @include outer-container;
 }
 
+.u-nowrap {
+  white-space: nowrap;
+}
+
 // Container
 //
 // Wrap content in a max width container plus standard padding.
@@ -157,10 +161,6 @@ ol.decimal,
 .u-group_inline-right {
   display: table-cell;
   vertical-align: middle;
-
-  .button-add { //TODO this shouldn't be in utilities
-    margin-top: 17px;
-  }
 }
 
 // Horizontal & Vertical Block Center

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -147,13 +147,13 @@ ol.decimal,
   width: 100%;
 }
 
-.group_inline-left
+.group_inline-left,
 .u-group_inline-left {
   display: table-cell;
   padding-right: 8px;
 }
 
-.group_inline-right
+.group_inline-right,
 .u-group_inline-right {
   display: table-cell;
   vertical-align: middle;

--- a/_sass/base/components/_buttons.scss
+++ b/_sass/base/components/_buttons.scss
@@ -78,12 +78,16 @@ input[type="submit"] {
     }
   }
 
+  &.button-add,
+  &.button-remove {
+    width: auto;
+    min-width: 50px;
+  }
+
   &.button-add {
     @extend .link-more;
     background-color: $white;
     color: $green;
-    letter-spacing: 0;
-    width: 50px;
 
     &:hover,
     &:focus {

--- a/_sass/base/components/_buttons.scss
+++ b/_sass/base/components/_buttons.scss
@@ -80,11 +80,14 @@ input[type="submit"] {
 
   &.button-add,
   &.button-remove {
+    white-space: normal;
+    letter-spacing: 0;
     width: auto;
     min-width: 50px;
   }
 
   &.button-add {
+    width: 50px;
     @extend .link-more;
     background-color: $white;
     color: $green;

--- a/_sass/base/components/_combo-box.scss
+++ b/_sass/base/components/_combo-box.scss
@@ -1,0 +1,38 @@
+combo-box {
+  display: block;
+  position: relative;
+
+  .combo-box_options {
+    background: $white;
+    border: 1px solid $mid-blue;
+    max-height: 10em;
+    overflow-y: auto;
+    position: absolute;
+    top: 100%;
+    width: 100%;
+
+    .combo-box_option {
+      display: block;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      label {
+        display: block;
+        padding: .5em;
+
+        input {
+          display: inline-block;
+        }
+
+        &:hover {
+          background: $light-gray;
+        }
+      }
+
+      &.combo-box_option_focus {
+        background: $light-blue;
+      }
+    }
+  }
+}

--- a/_sass/base/components/_combo-box.scss
+++ b/_sass/base/components/_combo-box.scss
@@ -2,7 +2,7 @@ combo-box {
   display: block;
   position: relative;
 
-  .combo-box_options {
+  [role="listbox"] {
     background: $white;
     border: 1px solid $mid-blue;
     max-height: 10em;
@@ -11,7 +11,7 @@ combo-box {
     top: 100%;
     width: 100%;
 
-    .combo-box_option {
+    [role="option"] {
       display: block;
       list-style: none;
       margin: 0;

--- a/_sass/base/components/_forms.scss
+++ b/_sass/base/components/_forms.scss
@@ -136,8 +136,8 @@ label.radio :checked + span {
   position: relative;
 }
 
-input[type="checkbox"],
-input[type="radio"] {
+label.checkbox input[type="checkbox"],
+label.radio input[type="radio"] {
   @include appearance(none);
   display: inline-block;
   height: 20px;

--- a/_sass/base/components/_forms.scss
+++ b/_sass/base/components/_forms.scss
@@ -183,7 +183,7 @@ select {
   color: $dark-gray;
   margin-bottom: 1em;
   overflow: hidden;
-  padding: 0.5em 7rem 0.5em 0.8rem;
+  padding: 0.5em 2rem 0.5em 0.8rem;
   text-overflow: ellipsis;
   white-space: nowrap;
 

--- a/_sass/base/components/_multi-select.scss
+++ b/_sass/base/components/_multi-select.scss
@@ -6,11 +6,11 @@ multi-select {
       display: none;
     }
 
-    &:last-child .button-add {
+    &:last-of-type .button-add {
       display: inline-block;
     }
 
-    &:first-child:last-child .button-remove {
+    &:first-of-type:last-of-type .button-remove {
       display: none;
     }
 

--- a/_sass/base/components/_multi-select.scss
+++ b/_sass/base/components/_multi-select.scss
@@ -1,0 +1,19 @@
+multi-select {
+
+  .multi-select_item {
+
+    .button-add {
+      display: none;
+    }
+
+    &:last-child .button-add {
+      display: inline-block;
+    }
+
+    &:first-child:last-child .button-remove {
+      display: none;
+    }
+
+  }
+
+}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 scripts:
   - vendor/formdb.min.js
+  - components/combo-box.js
 body_scripts:
   - index.js
 ---

--- a/js/components/aria-accordion.js
+++ b/js/components/aria-accordion.js
@@ -6,7 +6,7 @@
 
   // because PhantomJS and oldIE don't implement CustomEvent
   if (!window.CustomEvent) {
-    var CustomEvent = function(event, params) {
+    window.CustomEvent = function(event, params) {
       var evt;
       params = params || {
         bubbles: false,
@@ -17,8 +17,7 @@
       evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
       return evt;
     };
-    CustomEvent.prototype = window.Event.prototype;
-    window.CustomEvent = CustomEvent;
+    window.CustomEvent.prototype = window.Event.prototype;
   }
 
   exports.ARIAAccordion = document.registerElement('aria-accordion', {

--- a/js/components/combo-box.js
+++ b/js/components/combo-box.js
@@ -10,12 +10,12 @@
         }},
 
         attachedCallback: {value: function() {
-          this.__input = this.querySelector('.combo-box_search, input[type="text"]');
+          this.__input = this.querySelector('[role="combobox"]');
           if (!this.__input) {
             return console.warn('no input found in <combo-box>');
           }
 
-          this.__list = this.querySelector('.combo-box_options');
+          this.__list = this.querySelector('[role="listbox"]');
           if (!this.__list) {
             return console.warn('no list found in <combo-box>');
           }
@@ -237,7 +237,7 @@
 
   function getOptions(root) {
     return [].slice.call(
-      root.querySelectorAll('.combo-box_option')
+      root.querySelectorAll('[role="option"]')
     );
   }
 

--- a/js/components/combo-box.js
+++ b/js/components/combo-box.js
@@ -1,0 +1,244 @@
+(function(exports) {
+
+  var focusClass = 'combo-box_option_focus';
+
+  exports.ComboBox = document.registerElement('combo-box', {
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        createdCallback: {value: function() {
+        }},
+
+        attachedCallback: {value: function() {
+          this.__input = this.querySelector('.combo-box_search, input[type="text"]');
+          if (!this.__input) {
+            return console.warn('no input found in <combo-box>');
+          }
+
+          this.__list = this.querySelector('.combo-box_options');
+          if (!this.__list) {
+            return console.warn('no list found in <combo-box>');
+          }
+          hide(this.__list);
+
+          this.__list.addEventListener('click', this.__onclick = onclick.bind(this));
+
+          this.__input.addEventListener('focus', this.__onfocus = onfocus.bind(this));
+          this.__input.addEventListener('keydown', this.__onkeydown = onkeydown.bind(this));
+          this.__input.addEventListener('blur', this.__onfocus = onblur.bind(this));
+        }},
+
+        attributeChangedCallback: {value: function(attr, oldValue, newValue) {
+        }},
+
+        detachedCallback: {value: function() {
+          this.__list.removeEventListener('click', this.__onclick);
+
+          this.__input.removeEventListener('focus', this.__onfocus);
+          this.__input.removeEventListener('keydown', this.__onkeydown);
+          this.__input.removeEventListener('blur', this.__onfocus);
+        }}
+      }
+    )
+  });
+
+  function onfocus(e) {
+    show(this.__list);
+    updateVisibleOptions(this);
+    cancelHide(this);
+  }
+
+  function onkeydown(e) {
+    // console.log('key:', e.keyCode);
+    switch (e.keyCode) {
+
+      case 13: // enter
+        toggleFocused(this);
+        e.preventDefault();
+        var form = this.__input.form;
+        var onsubmit = function(e) {
+          console.warn('cancelling submission');
+          form.removeEventListener('submit', onsubmit);
+          e.preventDefault();
+          return false;
+        };
+        form.addEventListener('submit', onsubmit);
+        return false;
+
+      case 40: // down arrow
+        e.preventDefault();
+        moveDown(this);
+        return false;
+        
+      case 38: // up arrow
+        e.preventDefault();
+        moveUp(this);
+        return false;
+
+      case 27: // escape
+        this.__input.value = '';
+        break;
+    }
+
+    clearTimeout(this.__updateTimeout);
+    var root = this;
+    this.__updateTimeout = setTimeout(function() {
+      updateVisibleOptions(root);
+    }, 20);
+  }
+
+  function onclick(e) {
+    this.__input.focus();
+    selectAll(this.__input);
+    cancelHide(this);
+  }
+
+  function onblur(e) {
+    var list = this.__list;
+    this.__hideTimeout = setTimeout(function() {
+      hide(list);
+    }, 100);
+  }
+
+  function cancelHide(el) {
+    clearTimeout(el.__hideTimeout);
+  }
+
+  function show(el) {
+    el.style.removeProperty('display');
+  }
+
+  function hide(el) {
+    el.style.setProperty('display', 'none');
+  }
+
+  function getFocused(root) {
+    return root.querySelector('.' + focusClass);
+  }
+
+  function toggleFocused(root) {
+    var focused = getFocused(root);
+    if (focused) {
+      var input = focused.querySelector('input');
+      input.checked = !input.checked;
+      return input.checked;
+    }
+    return null;
+  }
+
+  function updateVisibleOptions(root) {
+    var value = root.__input.value;
+    var matches = function(text) {
+      // console.log('match "%s" with "%s"', value, text);
+      return text.toLowerCase().indexOf(value) > -1;
+    };
+
+    var options = getOptions(root);
+    var focused = false;
+    var visible = options
+      .filter(function(option, i) {
+        var input = option.querySelector('input');
+        var text = input.value;
+        var labelSelector = '.combo-box_label';
+        if (input.id) {
+          labelSelector += ', [for="' + input.id + '"]';
+        }
+        var label = option.querySelector(labelSelector);
+        if (label) {
+          if (label.hasAttribute('data-text')) {
+            text = label.getAttribute('data-text');
+          } else {
+            label.setAttribute('data-text', text = label.textContent);
+          }
+        }
+        var visible = value && text
+          ? matches(text)
+          : true;
+        if (visible) {
+          show(option);
+          if (label) {
+            var index = text.toLowerCase().indexOf(value);
+            label.innerHTML = [
+              text.substr(0, index),
+              '<u>',
+              text.substr(index, value.length),
+              '</u>',
+              text.substr(index + value.length)
+            ].join('');
+          }
+        } else {
+          hide(option);
+          if (label) label.textContent = text;
+        }
+        var focus = visible && !focused;
+        option.classList.toggle(focusClass, focus);
+        if (focus) focused = focus;
+        return visible;
+      });
+    // console.log('%d of %d options visible', visible.length, options.length);
+  }
+
+  function moveUp(root) {
+    var focused = getFocused(root);
+    return move(focused, true);
+  }
+
+  function moveDown(root) {
+    var focused = getFocused(root);
+    return move(focused, false);
+  }
+
+  function move(node, up) {
+    console.log('move', node, up);
+    var original = node;
+    var prop = up ? 'previousSibling' : 'nextSibling';
+    while (node = node[prop]) {
+      if (node.nodeType === 1 && isVisible(node)) {
+        break;
+      }
+    }
+
+    if (node && node !== original) {
+      original.classList.remove(focusClass);
+      node.classList.add(focusClass);
+      scrollTo(node);
+      return true;
+    }
+    return node;
+  }
+
+  function isVisible(el) {
+    return el.style.getPropertyValue('display') !== 'none';
+  }
+
+  function scrollTo(node) {
+    var parent = node.parentNode;
+    var outer = parent.getBoundingClientRect();
+    var inner = node.getBoundingClientRect();
+    var top = inner.top - outer.top;
+    console.log('top:', top, 'scrollTop:', parent.scrollTop);
+    if (inner.bottom > outer.bottom) {
+      console.warn('out of bounds (below)');
+      parent.scrollTop += inner.bottom - outer.bottom;
+    } else if (inner.top < outer.top) {
+      console.warn('out of bounds (above)');
+      parent.scrollTop -= outer.top - inner.top;
+    }
+  }
+
+  function selectAll(input) {
+    if (typeof input.select === 'function') {
+      input.select();
+    }
+    if (typeof input.setSelectionRange === 'function') {
+      input.setSelectionRange(0, input.value.length);
+    }
+  }
+
+  function getOptions(root) {
+    return [].slice.call(
+      root.querySelectorAll('.combo-box_option')
+    );
+  }
+
+})(this);

--- a/js/components/combo-box.js
+++ b/js/components/combo-box.js
@@ -199,7 +199,7 @@
   }
 
   function move(node, up) {
-    console.log('move', node, up);
+    // console.log('move', node, up);
     var original = node;
     var prop = up ? 'previousSibling' : 'nextSibling';
     while (node = node[prop]) {

--- a/js/components/multi-select.js
+++ b/js/components/multi-select.js
@@ -1,0 +1,164 @@
+(function(exports) {
+
+  var ITEM_CLASS = 'multi-select_item';
+
+  exports.MultiSelect = document.registerElement('multi-select', {
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        createdCallback: {value: function() {
+        }},
+
+        attachedCallback: {value: function() {
+          var select = this.querySelector('select');
+          if (!select) return console.error('no <select> found in <multi-select>!');
+
+          this.name = select.name;
+          select.name = '';
+
+          this.createTemplate();
+          this.update();
+        }},
+
+        attributeChangedCallback: {value: function(attr, oldValue, newValue) {
+        }},
+
+        detachedCallback: {value: function() {
+        }},
+
+        update: {value: function() {
+          var root = d3.select(this);
+          var values = this.value;
+          // console.log('[update]');
+
+          var set = (function(v, focus) {
+            // console.log('[set] values:', v);
+            this.value = v;
+            if (focus) {
+              this.querySelector('.' + ITEM_CLASS + ':last-child select').focus();
+            }
+          }).bind(this);
+
+          var items = root
+            .selectAll('.' + ITEM_CLASS)
+            .data(values);
+
+          var template = this.__template;
+          items.exit().remove();
+          items.enter()
+            .append(function() {
+              return template.cloneNode(true);
+            })
+            .classed(ITEM_CLASS, true);
+
+          items.select('select')
+            .property('value', function(d) {
+              return nullish(d) ? '' : String(d);
+            })
+            .on('change', function(d, i) {
+              values[i] = this.value;
+              set(values);
+            });
+
+          /*
+          items.select('button')
+            .attr('disabled', 'disabled');
+          */
+
+          items.selectAll('button')
+            .on('click.cancel', function() {
+              d3.event.preventDefault();
+            });
+
+          items.each(function(value, i) {
+            var item = d3.select(this);
+            item.select('.button-remove')
+              .on('click', remove);
+            item.select('.button-add')
+              .on('click', add);
+            function remove() {
+              item.remove();
+              values.splice(i, 1);
+              // console.log('[remove %d]:', i, value);
+              // console.log('values:', values);
+              set(values);
+            }
+          })
+
+          function add() {
+            values.push(null);
+            set(values, true);
+          }
+
+        }},
+
+        createTemplate: {value: function() {
+          if (!this.__template) {
+            var html = this.innerHTML;
+            var template = this.__template = document.createElement('div');
+            template.className = ITEM_CLASS;
+            template.innerHTML = html;
+            while (this.firstChild) {
+              this.removeChild(this.firstChild);
+            }
+            return template;
+          }
+          return this.__template;
+        }},
+
+        type: {
+          get: function() {
+            return 'text';
+          }
+        },
+
+        name: {
+          get: function() {
+            return this.getAttribute('name');
+          },
+          set: function(name) {
+            this.setAttribute('name', name);
+          }
+        },
+
+        value: {
+          get: function() {
+            return Array.isArray(this.__value)
+              ? this.__value.slice()
+              : this.__value || [null];
+          },
+          set: function(value) {
+            // console.log('[set values]:', value);
+            if (compare(this.__value, value)) {
+              console.warn('no change');
+              return;
+            }
+
+            this.__value = parseValues(value);
+            this.update();
+
+            this.dispatchEvent(new CustomEvent('change', {
+              bubbles: true
+            }));
+          }
+        }
+      }
+    )
+  });
+
+  function parseValues(d) {
+    return Array.isArray(d)
+      ? d
+      : d ? String(d).split(/,/g) : [d];
+  }
+
+  function nullish(d) {
+    return d === null || d === undefined;
+  }
+
+  // fast compare
+  function compare(a, b) {
+    return String(a) === String(b);
+  }
+
+})(this);

--- a/js/components/multi-select.js
+++ b/js/components/multi-select.js
@@ -206,8 +206,13 @@
     return d === null || d === undefined;
   }
 
-  // fast compare
+  // Array comparison
   function compare(a, b) {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      for (var i = 0, len = a.length; i < len; i++) {
+        if (b.indexOf(a[i]) === -1) return false;
+      }
+    }
     return String(a) === String(b);
   }
 

--- a/js/index.js
+++ b/js/index.js
@@ -3,4 +3,13 @@
   var form = new formdb.Form('#search-form');
   picc.form.minifyQueryString(form);
 
+  if (location.hash.length > 1) {
+    var id = location.hash.substr(1);
+    picc.ui.expandAccordions(function() {
+      return this.id && this.id === id;
+    });
+    location.hash = '';
+    location.hash = '#' + id;
+  }
+
 })(this);

--- a/js/picc.js
+++ b/js/picc.js
@@ -559,7 +559,7 @@
 
       race_ethnicity_values: function(d) {
         if (!d.demographics || !d.metadata) {
-          console.warn('no demographics or metadata:', d);
+          // console.warn('no demographics or metadata:', d);
           return [];
         }
 

--- a/js/picc.js
+++ b/js/picc.js
@@ -31,6 +31,9 @@
       } else if (params) {
         if (typeof params === 'object') {
           if (API.key) params.api_key = API.key;
+          // collapse arrays into comma-separated strings
+          // per the API
+          collapseArrays(params);
           params = querystring.stringify(params);
         } else if (API.key) {
           params += '&api_key=' + API.key;
@@ -99,6 +102,16 @@
         }
       }
       return list.join(glue);
+    }
+
+    function collapseArrays(obj, glue) {
+      if (!glue) glue = ',';
+      for (var key in obj) {
+        if (Array.isArray(obj[key])) {
+          obj[key] = obj[key].join(glue);
+        }
+      }
+      return obj;
     }
 
     return API;

--- a/js/picc.js
+++ b/js/picc.js
@@ -662,7 +662,6 @@
     return form;
   };
 
-
   // UI tools
   picc.ui = {};
 
@@ -680,6 +679,15 @@
         return !!expanded.apply(this, arguments);
       })
       .property('expanded', true);
+  };
+
+  // this is the equivalent of $(function), aka DOMReady
+  picc.ready = function(callback) {
+    if (document.readyState === 'complete') {
+      return callback();
+    } else {
+      window.addEventListener('load', callback);
+    }
   };
 
   // debounce function

--- a/js/search.js
+++ b/js/search.js
@@ -1,16 +1,19 @@
 (function(exports) {
 
   var resultsRoot = document.querySelector('.search-results');
-
   var form = new formdb.Form('#search-form');
-
   var query = querystring.parse(location.search.substr(1));
-  form.setData(query);
-
   // the current outbound request
   var req;
 
-  onChange(form.getData());
+  picc.ready(function() {
+    // console.warn('setting form data...', query);
+    // console.log('states:', form.get('state'));
+    form.setData(query);
+    // console.log('states:', form.getInputsByName('state'), form.get('state'));
+
+    onChange(form.getData());
+  });
 
   form.on('change', picc.debounce(onChange, 200));
 

--- a/search/index.html
+++ b/search/index.html
@@ -3,6 +3,7 @@ title: Search
 layout: default
 permalink: /search/
 scripts:
+  - components/combo-box.js
   - components/picc-slider.js
   - vendor/formdb.min.js
   - vendor/tagalong.min.js


### PR DESCRIPTION
This PR resolves #37 by implementing @jjoteal's design for the multi-state search. Here's how it works:

There's a new `<multi-select>` element that manages one or more `<select>` elements within it, and exposes an *input-like* API of its own: it has `name`, `type`, and `value` properties, and dispatches `change` events whenever its value changes. This means that the library we're using to get and set form data ([formdb]) treats it just like any other form element.

The `<multi-select>` element treats its initial contents as a "template" that's repeated when its value is set (either as an array or when parsed as one via comma-separated strings). So you can set the state element's value to `'CA'` and it'll show one drop-down with that value selected:

![image](https://cloud.githubusercontent.com/assets/113896/9102501/0a39b974-3ba8-11e5-843b-28e728f0f228.png)

When you click on the "ADD" button (it looks for the `.button-add` selector), a new copy of that template is created and focused, then the "&times;" buttons (`.button-remove`) show up via CSS:

![image](https://cloud.githubusercontent.com/assets/113896/9102517/38cdbbfa-3ba8-11e5-94f7-f19123d3e20c.png)

Either of these values can be removed, or you can keep adding states. (One improvement might be to disable the "ADD" button until its corresponding element's value is set.)

Behind the scenes, the individual `<select>` elements' names are removed (so they don't get submitted with the form), and a hidden input is set to the stringified representation of the value. This could probably be simplified, but it works for now so I'm inclined not to monkey with it too much.

On the search page, you can add and remove states and the search results should update dynamically. The whole sidebar needs a bunch of CSS love from @meiqimichelle before it's really usable, though, so I'm assigning this to her.

[formdb]: https://github.com/shawnbot/formdb