### PR TITLE
Updates to 'degree' section of search

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -149,19 +149,19 @@
 
     <aria-accordion id="degree-accordion" class="container">
 
-      <legend>Major/Degree</legend>
+      <legend>Area of Study</legend>
       <h1 class="search_category">
         <a aria-expanded="false" aria-controls="major-content">
-          Major/Degree
+          Area of Study
         </a>
       </h1>
       <div id="major-content" aria-hidden="true" class="accordion-div">
 
-        <label for="major">Specify a major or degree
-          <input id="major" name="major" type="text" placeholder="Type a major" {{ common_input_attributes }}>
-        </label>
+        <!-- <label for="major">Choose a program
+          <input id="major" name="major" type="text" placeholder="e.g. Engineering" {{ common_input_attributes }}>
+        </label> -->
 
-        <label for="major-type">Select a type of degree
+        <label for="major-type">Choose a program
           <select id="major-type" name="major_type">
             <option value=""></option>
             <option>???</option>


### PR DESCRIPTION
This resolves #281.

- Changes title of section to Area of Study
- Removes one of the input areas
- Changes next on remaining select input to better reflect title text change

![screen shot 2015-08-06 at 10 26 26 pm](https://cloud.githubusercontent.com/assets/4827522/9129272/7d57bb3a-3c8a-11e5-9aca-1a6a1a2cc149.png)

@shawnbot I left the second input in the HTML, commented out, because I wasn't sure if you wanted to do a type-ahead here or a drop-down. The content (text) have been updated in both so whichever you use to hook up the data you're good to go.