### PR TITLE
Add support for branch-specific API URLs in Federalist

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
-  <body data-branch="{{ site.branch }}">
+  <body data-env="{{ site.branch }}">
     {% include header.html %}
 
     <main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
-  <body>
+  <body data-branch="{{ site.branch }}">
     {% include header.html %}
 
     <main>

--- a/js/picc.js
+++ b/js/picc.js
@@ -27,8 +27,13 @@
    */
   picc.API = (function() {
     var API = {
+      {% if site.API[site.branch] %}
+      url: '{{ site.API[site.branch].baseurl }}',
+      key: '{{ site.API[site.branch].key }}'
+      {% else %}
       url: '{{ site.API.baseurl }}',
       key: '{{ site.API.key }}'
+      {% endif %}
     };
 
     // the API endpoint (URI) at which to find school data

--- a/js/picc.js
+++ b/js/picc.js
@@ -26,6 +26,7 @@
    *
    */
   picc.API = (function() {
+    // site.branch = '{{ site.branch }}'
     var API = {
       {% if site.API[site.branch] %}
       url: '{{ site.API[site.branch].baseurl }}',


### PR DESCRIPTION
This adds support for branch-specific API configurations in Federalist. This means that we can use a custom config that looks like:

```yaml
API:
  # this is the default
  baseurl: https://api.data/gov/secret-api/beta/

  # these are branch-specific
  dev:
    baseurl: https://api.data.gov/secret-api/dev/
  staging:
    baseurl: https://api.data.gov/secret-api/staging/
  master:
    baseurl: https://api.data.gov/secret-api/production/
```

If you're using a `_config.local.yml` for local testing, you shouldn't need to change anything because the `site.branch` Liquid variable will be unset, and it should use whatever you've specified in your local config's `API` variable. You can confirm that this is the case by looking at the rendered HTML source of any page and checking the `data-env` attribute of the `<body>` element, which should be blank locally. As a bonus, we can use this attribute to style the site differently in the future so it's clear that we're looking at different environments! :sparkles: 