### PR TITLE
Enable slider fields

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -33,7 +33,7 @@
         <div class="filter_section">
           <h2>Cost Per Year</h2>
           <picc-slider format="$" max="50000" average="22000">
-            <input type="hidden" name="average_cost_range">
+            <input type="hidden" name="2013.cost.avg_net_price.private__range">
           </picc-slider>
         </div>
 
@@ -41,21 +41,21 @@
         <div class="filter_section">
           <h2>Graduation Rate</h2>
           <picc-slider format="%" max="1">
-            <input type="hidden" name="graduation_rate_range">
+            <input type="hidden" name="2013.completion.rate.four_year__range">
           </picc-slider>
         </div>
 
         <div class="filter_section">
           <h2>Salary After Graduation</h2>
           <picc-slider format="$" max="50000" average="25000">
-            <input type="hidden" name="average_salary_range">
+            <input type="hidden" name="2011.earnings.6_yrs_after_entry.mean_earnings.lowest_tercile__range">
           </picc-slider>
         </div>
 
         <div class="filter_section">
           <h2>Monthly Student Loan Payment</h2>
           <picc-slider format="$" max="500" average="280">
-            <input type="hidden" name="monthly_loan_payment_range">
+            <input type="hidden" name="2013.debt.median_debt_suppressed.completers.monthly_payments__range">
           </picc-slider>
         </div>
 

--- a/js/components/picc-slider.js
+++ b/js/components/picc-slider.js
@@ -148,10 +148,6 @@
       this.setAttribute('aria-valuemin', lower);
       this.setAttribute('aria-valuemax', upper);
 
-      this.dispatchEvent(new CustomEvent('change', {
-        min: lower,
-        max: upper
-      }));
     },
 
     // clamp to min and max, round if snap === true
@@ -233,6 +229,17 @@
     window.removeEventListener('touchmove', getListener(move, this));
     window.removeEventListener('mouseup', getListener(release, this));
     window.removeEventListener('touchend', getListener(release, this));
+
+    var lower = this.lower;
+    var upper = this.upper;
+    this.getElementsByTagName("input")[0].setAttribute("value", lower+".."+upper);
+
+    this.dispatchEvent(new CustomEvent('change', {
+      min: lower,
+      max: upper,
+      bubbles: true
+    }));
+
     e.preventDefault();
     return false;
   }

--- a/js/picc.js
+++ b/js/picc.js
@@ -409,7 +409,7 @@
     MEDIAN_EARNINGS:      '2011.earnings.6_yrs_after_entry.median',
 
     // FIXME: pending #373
-    EARNINGS_GT_25K:      '2011.earnings.gt_25k_p10',
+    EARNINGS_GT_25K:      '2011.earnings.threshold_earnings_percent',
 
     PROGRAM_PERCENTAGE:   '2013.academics.program_percentage',
 

--- a/js/search.js
+++ b/js/search.js
@@ -61,9 +61,6 @@
     // set the predominant degree, which can be either a value or
     // a range (default: '2..3')
     if (query.degree) {
-      // FIXME: when we have support for nested keys,
-      // 'predominant' should be changed to
-      // `picc.fields.PREDOMINANT_DEGREE`
       picc.data.rangify(query, picc.fields.PREDOMINANT_DEGREE, query.degree);
       delete query.degree;
     }

--- a/js/search.js
+++ b/js/search.js
@@ -64,7 +64,7 @@
       // FIXME: when we have support for nested keys,
       // 'predominant' should be changed to
       // `picc.fields.PREDOMINANT_DEGREE`
-      picc.data.rangify(query, 'predominant', query.degree);
+      picc.data.rangify(query, picc.fields.PREDOMINANT_DEGREE, query.degree);
       delete query.degree;
     }
 

--- a/search/index.html
+++ b/search/index.html
@@ -62,7 +62,7 @@ body_scripts:
               <!-- <div class="u-group_inline-right"> -->
                 <label for="select-sort">Sort by:</label>
                 <select id="select-sort" name="sort">
-                  <option selected value="2011.earnings.gt_25k_p10:desc">Earnings</option>
+                  <option selected value="2011.earnings.threshold_earnings_percent:desc">Earnings</option>
                   <option value="2013.student.size:asc">Size (small to large)</option>
                   <option value="2013.student.size:desc">Size (large to small)</option>
                 </select>


### PR DESCRIPTION
... and fix field names.

We are now sorting by:  2011.earnings.threshold_earnings_percent:desc
Salary After Graduation is: 2011.earnings.6_yrs_after_entry.mean_earnings.lowest_tercile
Montly student loan payment: 2013.debt.median_debt_suppressed.completers.monthly_payments

Cost is incorrect filtering only private schools:  2013.cost.avg_net_price.private
Comletion rate is also incorrect, tied to only 4 year schools: 2013.completion.rate.four_year

Note: requires https://github.com/18F/open-data-maker/pull/118 to be deployed on the API server.