### PR TITLE
school name in browser title

### DIFF
--- a/js/school.js
+++ b/js/school.js
@@ -32,7 +32,7 @@
     var school = data.school;
 
     var name = picc.access(picc.fields.NAME)(school);
-    document.title += ' / ' + name;
+    document.title = name;
 
     school.metadata = data.metadata;
     console.log('got school:', school);


### PR DESCRIPTION
Used to say “School / Whatever University”
now just has the school name
addresses #478 (at least partially)