### PR TITLE
Normalize search URLs

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -59,7 +59,7 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="$" max="50000" average="25000">
+          <picc-slider format="$" max="250000">
             <input type="hidden" name="median_earnings">
           </picc-slider>
         </div>
@@ -70,7 +70,7 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="$" max="500" average="280">
+          <picc-slider format="$" max="1000" step="50">
             <input type="hidden" name="monthly_payments">
           </picc-slider>
         </div>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -6,7 +6,7 @@
 
   {% capture common_input_attributes %}autocomplete="off" autocorrect="off" autocapitalize="off"{% endcapture %}
 
-  <input type="hidden" name="school.HCM2">
+  <input type="hidden" name="under_investigation">
 
   <div class="container search-form-intro">
 
@@ -36,8 +36,8 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="$" max="50000" average="22000">
-            <input type="hidden" name="2013.cost.avg_net_price.overall__range">
+          <picc-slider format="$" max="90000" step="1000">
+            <input type="hidden" name="avg_net_price">
           </picc-slider>
         </div>
 
@@ -48,8 +48,8 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="%" max="1">
-            <input type="hidden" name="2013.completion.rate_suppressed.overall__range">
+          <picc-slider format="%" max="1" step=".01">
+            <input type="hidden" name="completion_rate">
           </picc-slider>
         </div>
 
@@ -60,7 +60,7 @@
             </a>
           </h2>
           <picc-slider format="$" max="50000" average="25000">
-            <input type="hidden" name="2011.earnings.10_yrs_after_entry.median__range">
+            <input type="hidden" name="median_earnings">
           </picc-slider>
         </div>
 
@@ -71,7 +71,7 @@
             </a>
           </h2>
           <picc-slider format="$" max="500" average="280">
-            <input type="hidden" name="2013.aid.median_debt_suppressed.completers.monthly_payments__range">
+            <input type="hidden" name="monthly_payments">
           </picc-slider>
         </div>
 
@@ -185,7 +185,7 @@
         </div>
 
         <label for="online" class="checkbox">
-          <input id="online" type="checkbox" name="size" value="online" tabindex="0">
+          <input id="online" type="checkbox" name="online" value="1" tabindex="0">
           <span tabindex="-1" class="checkbox-focus"></span>Include Online Only Schools
         </label>
 
@@ -213,9 +213,9 @@
 
         <label for="major-type">Choose a program
           <select id="major-type" name="degree">
-            <option value="2..3">Any</option>
-            <option value="2">Associates</option>
-            <option value="3">Bachelors</option>
+            <option value="">Any</option>
+            <option value="a">Associates</option>
+            <option value="b">Bachelors</option>
           </select>
         </label>
       </div>
@@ -244,19 +244,19 @@
           <ul>
             <li>
               <label for="size-small" class="checkbox">
-                <input id="size-small" type="checkbox" name="size" value="..1999" tabindex="0">
+                <input id="size-small" type="checkbox" name="size" value="small" tabindex="0">
                 <span tabindex="-1" class="checkbox-focus"></span>Small (&lt; 2,000)
               </label>
             </li>
             <li>
               <label for="size-medium" class="checkbox">
-                <input id="size-medium" type="checkbox" name="size" value="2000..15000" tabindex="0">
+                <input id="size-medium" type="checkbox" name="size" value="medium" tabindex="0">
                 <span tabindex="-1" class="checkbox-focus"></span>Medium (2,000&ndash;15,000)
               </label>
             </li>
             <li>
               <label for="size-large" class="checkbox">
-                <input id="size-large" type="checkbox" name="size" value="15001.." tabindex="0">
+                <input id="size-large" type="checkbox" name="size" value="large" tabindex="0">
                 <span tabindex="-1" class="checkbox-focus"></span>Large (&gt; 15,000)
               </label>
             </li>

--- a/js/picc.js
+++ b/js/picc.js
@@ -409,13 +409,11 @@
 
     MEDIAN_EARNINGS:      '2011.earnings.10_yrs_after_entry.median',
 
-    // FIXME: pending #373
     EARNINGS_GT_25K:      '2011.earnings.6_yrs_after_entry.percent_greater_than_25000',
 
     PROGRAM_PERCENTAGE:   '2013.academics.program_percentage',
 
-    // FIXME: will become `2013.student.demographics.female_share`
-    FEMALE_SHARE:         '2013.student.female',
+    FEMALE_SHARE:         '2013.student.demographics.female_share',
     RACE_ETHNICITY:       '2013.student.demographics.race_ethnicity',
     AGE_ENTRY:            '2013.student.demographics.age_entry',
 
@@ -717,6 +715,7 @@
       state:          access(fields.STATE),
 
       under_investigation: underInvestigation,
+
       // FIXME this is a hack to deal with the issue of tagalong
       // not applying a directive to multiple elements
       under_investigation2: underInvestigation,

--- a/js/picc.js
+++ b/js/picc.js
@@ -392,13 +392,11 @@
     UNDER_INVESTIGATION:  'school.HCM2',
 
     // net price
-    // FIXME: where is NET_PRICE_BY_INCOME used?
-    NET_PRICE_ROOT:       '2013.cost.avg_net_price',
     NET_PRICE:            '2013.cost.avg_net_price.overall',
     NET_PRICE_BY_INCOME:  '2013.cost.net_price',
 
     // completion rate
-    COMPLETION_RATE:      '2013.completion.rate_suppressed',
+    COMPLETION_RATE:      '2013.completion.rate_suppressed.overall',
 
     RETENTION_RATE:       '2013.student.retention_rate',
 
@@ -548,7 +546,9 @@
     }
   };
 
-  picc.access.netPrice = picc.access(picc.fields.NET_PRICE);
+  picc.access.netPrice = picc.access.composed(
+    picc.fields.NET_PRICE
+  );
 
   picc.access.netPriceByIncomeLevel = function(level) {
     return picc.access.composed(
@@ -567,23 +567,9 @@
     picc.fields.EARNINGS_GT_25K
   );
 
-  picc.access.completionRate = function(d) {
-    var key = picc.access.yearDesignation(d);
-    var rate = picc.access(picc.fields.COMPLETION_RATE)(d);
-    if (!rate) {
-      // XXX: this is for when the data is accessed as a
-      // "pre-nested" field, which is how Elasticsearch
-      // expresses data when you ask it for specific fields
-      var four = picc.access.composed(picc.fields.COMPLETION_RATE, 'four_year')(d);
-      var less = picc.access.composed(picc.fields.COMPLETION_RATE, 'lt_four_year')(d);
-      return four || less;
-    }
-    if (rate[key] === 0) {
-      console.warn('completion rate key mismatch: expected "%s", but got zero:', key, rate);
-      return rate.four_year || rate.lt_four_year;
-    }
-    return rate[key];
-  };
+  picc.access.completionRate = picc.access.composed(
+    picc.fields.COMPLETION_RATE
+  );
 
   picc.access.partTimeShare = function(d) {
     // FIXME: this should be a single field?

--- a/js/picc.js
+++ b/js/picc.js
@@ -374,12 +374,15 @@
     NAME:                 'school.name',
     CITY:                 'school.city',
     STATE:                'school.state',
+    ZIP_CODE:             'school.zip',
+
     LOCATION:             'location',
     OWNERSHIP:            'school.ownership',
     LOCALE:               'school.locale',
     REGION_ID:            'school.region_id',
 
     SIZE:                 '2013.student.size',
+    DISTANCE_ONLY:        'school.DISTANCEONLY',
 
     WOMEN_ONLY:           'school.women_only',
     MEN_ONLY:             'school.men_only',
@@ -943,6 +946,34 @@
 
   // form utilities
   picc.form = {};
+
+  /**
+   * These are mappings of values for common form fields from
+   * URL- (and human-) friendly values to ones that the API
+   * recognizes.
+   */
+  picc.form.mappings = {
+    sort: {
+      advantage:          picc.fields.EARNINGS_GT_25K,
+      salary:             picc.fields.MEDIAN_EARNINGS,
+      name:               picc.fields.NAME,
+      size:               picc.fields.SIZE,
+      avg_net_price:      picc.fields.NET_PRICE,
+      completion_rate:    picc.fields.COMPLETION_RATE,
+    },
+
+    size: {
+      small:  '..1999',
+      medium: '2000..15000',
+      large:  '15001..'
+    },
+
+    degree: {
+      '': '2..3',
+      a: '2',
+      b: '3'
+    }
+  };
 
   /**
    * Adds a "submit" listener to the provided formdb.Form instance (or CSS

--- a/js/picc.js
+++ b/js/picc.js
@@ -1008,9 +1008,13 @@
       monthly_payments:     fields.MONTHLY_LOAN_PAYMENT + '__range',
 
       state:                fields.STATE,
-      region:               fields.REGION_ID,
       zip:                  fields.ZIP_CODE,
       online:               fields.DISTANCE_ONLY,
+
+      region: function(query, value, key) {
+        picc.data.rangify(query, picc.fields.REGION_ID, query.region);
+        delete query[key];
+      },
 
       sort: function(query, value, key) {
         var bits = String(value).split(':');
@@ -1032,12 +1036,16 @@
         }
       },
 
-      degree: function(query, value, key) {
-        query[key] = mapDegree(value);
+      size: function(query, value, key) {
+        value = mapSize(value);
+        query[picc.fields.SIZE + '__range'] = Array.isArray(value)
+          ? value.join(',')
+          : value;
+        delete query[key];
       },
 
-      size: function(query, value, key) {
-        query[key] = mapSize(value);
+      degree: function(query, value, key) {
+        query[key] = mapDegree(value);
       },
 
       // XXX: this is only used for testing
@@ -1100,19 +1108,6 @@
         if (query[key] === null || query[key] === undefined) {
           delete query[key];
         }
-      }
-
-      // if the region is specified, add it either as a value or a
-      // range with picc.data.rangify()
-      if (query.region) {
-        picc.data.rangify(query, picc.fields.REGION_ID, query.region);
-        delete query.region;
-      }
-
-      // if a size is specified, just pass it along as a range
-      if (query.size) {
-        picc.data.rangify(query, picc.fields.SIZE, query.size);
-        delete query.size;
       }
 
       // set the predominant degree, which can be either a value or

--- a/js/picc.js
+++ b/js/picc.js
@@ -1044,6 +1044,7 @@
       under_investigation:  picc.fields.UNDER_INVESTIGATION,
     };
 
+    // map a size or array of sizes to API-friendly range values
     function mapSize(value) {
       if (Array.isArray(value)) {
         return value.map(mapSize);
@@ -1051,6 +1052,8 @@
       return picc.form.mappings.size[value];
     }
 
+    // map a degree string ('', 'a' or 'b') or array of strings to an
+    // API-friendly "predominant degree" range value
     function mapDegree(value) {
       if (Array.isArray(value)) {
         return value.map(mapDegree);
@@ -1058,6 +1061,8 @@
       return picc.form.mappings.degree[value];
     }
 
+    // returns true if a value is an empty string, null, undefined, or an array
+    // with an empty 0 index value
     function empty(value) {
       return value === ''
           || value === null
@@ -1072,6 +1077,7 @@
       for (var key in query) {
         var v = query[key];
 
+        // delete empty keys
         if (empty(v)) {
           delete query[key];
           continue;

--- a/js/picc.js
+++ b/js/picc.js
@@ -955,7 +955,6 @@
     },
 
     degree: {
-      '': '2..3',
       a: '2',
       b: '3'
     }
@@ -1121,6 +1120,8 @@
       if (query.degree) {
         picc.data.rangify(query, picc.fields.PREDOMINANT_DEGREE, query.degree);
         delete query.degree;
+      } else {
+        query[picc.fields.PREDOMINANT_DEGREE + '__range'] = '2..3';
       }
 
       return query;

--- a/js/picc.js
+++ b/js/picc.js
@@ -1019,9 +1019,10 @@
       sort: function(query, value, key) {
         var bits = String(value).split(':');
         value = bits[0];
-        bits[0] = picc.form.mappings.sort[value] || value;
+        bits[0] = picc.form.mappings.sort[value];
         if (!bits[0]) {
           console.warn('unmapped sort value:', value);
+          bits[0] = value;
         }
         query[key] = bits.join(':');
       },

--- a/js/search.js
+++ b/js/search.js
@@ -107,6 +107,7 @@
 
     var qs = querystring.stringify(params);
     qs = qs.replace(/^&/, '');
+    qs = qs.replace(/&{2,}/g, '&');
     // update the URL
     history.pushState(params, 'search', '?' + qs);
 

--- a/js/search.js
+++ b/js/search.js
@@ -109,8 +109,9 @@
     ].join(',');
 
     var qs = querystring.stringify(params);
-    qs = qs.replace(/^&/, '');
-    qs = qs.replace(/&{2,}/g, '&');
+    qs = qs.replace(/^&/, '')
+      .replace(/&{2,}/g, '&')
+      .replace(/%3A/g, ':');
     // update the URL
     history.pushState(params, 'search', '?' + qs);
 

--- a/js/search.js
+++ b/js/search.js
@@ -90,13 +90,9 @@
       // to get the "four_year" or "lt_four_year" bit
       picc.fields.PREDOMINANT_DEGREE,
       // get all of the net price values
-      picc.fields.NET_PRICE_ROOT + '.overall',
-      picc.fields.NET_PRICE_ROOT + '.public',
-      picc.fields.NET_PRICE_ROOT + '.private',
-      // get all of the completion rate values
-      picc.fields.COMPLETION_RATE + '.overall',
-      picc.fields.COMPLETION_RATE + '.four_year',
-      picc.fields.COMPLETION_RATE + '.lt_four_year',
+      picc.fields.NET_PRICE,
+      // completion rate
+      picc.fields.COMPLETION_RATE,
       // this has no sub-fields
       picc.fields.MEDIAN_EARNINGS,
       // not sure if we need this, but let's get it anyway

--- a/js/search.js
+++ b/js/search.js
@@ -43,7 +43,13 @@
         // range value.
         var input = this.querySelector('input');
         if (input) {
-          input.value = [this.lower, this.upper].join('..');
+          if (this.lower > this.min || this.upper < this.max) {
+            // console.log('%d > %d || %d < %d', this.lower, this.min, this.upper, this.max);
+            input.value = [this.lower, this.upper].join('..');
+          } else {
+            // console.log('slider range @ limits:', this);
+            input.value = '';
+          }
           change();
         }
       }, 200));

--- a/js/search.js
+++ b/js/search.js
@@ -49,32 +49,7 @@
   function onChange() {
     var params = form.getData();
 
-    // console.log('search params:', params);
-    if (Array.isArray(params.state) && !params.state[0]) {
-      delete params.state;
-    }
-
-    var query = picc.data.extend({}, params);
-
-    // if the region is specified, add it either as a value or a
-    // range with picc.data.rangify()
-    if (query.region) {
-      picc.data.rangify(query, picc.fields.REGION_ID, query.region);
-      delete query.region;
-    }
-
-    // if a size is specified, just pass it along as a range
-    if (query.size) {
-      picc.data.rangify(query, picc.fields.SIZE, query.size);
-      delete query.size;
-    }
-
-    // set the predominant degree, which can be either a value or
-    // a range (default: '2..3')
-    if (query.degree) {
-      picc.data.rangify(query, picc.fields.PREDOMINANT_DEGREE, query.degree);
-      delete query.degree;
-    }
+    var query = picc.form.prepareParams(params);
 
     // only query the fields that we care about
     query.fields = [

--- a/search/index.html
+++ b/search/index.html
@@ -63,14 +63,14 @@ body_scripts:
               <!-- <div class="u-group_inline-right"> -->
                 <label for="select-sort">Sort by:</label>
                 <select id="select-sort" name="sort">
-                  <option selected value="2011.earnings.6_yrs_after_entry.percent_greater_than_25000:desc">Advantage Factor</option>
-                  <option value="2011.earnings.10_yrs_after_entry.median:desc">Salary</option>
-                  <option value="school.name:asc">Name (A to Z)</option>
-                  <!--option value="school.name:desc">Name (Z to A)</option -->
-                  <!--option value="2013.student.size:desc">Size (large to small)</option-->
-                  <option value="2013.student.size:asc">Size (small to large)</option>
-                  <option value="2013.cost.avg_net_price.overall:asc">Actual Cost</option>
-                  <option value="2013.completion.rate_suppressed.overall:desc">Graduation Rate</option>
+                  <option selected value="advantage:desc">Advantage Factor</option>
+                  <option value="salary:desc">Salary</option>
+                  <option value="name:asc">Name (A to Z)</option>
+                  <!--option value="name:desc">Name (Z to A)</option -->
+                  <!--option value="size:desc">Size (large to small)</option-->
+                  <option value="size:asc">Size (small to large)</option>
+                  <option value="avg_net_price:asc">Actual Cost</option>
+                  <option value="completion_rate:desc">Graduation Rate</option>
                 </select>
               <!-- </div> -->
 


### PR DESCRIPTION
This PR updates the search form to use more human-friendly names for fields and their respective values so that the search URLs don't include API-specific field names or values. This means that the search result URLs are cleaner and more resilient to future API changes, such as with field names. For instance, before these changes the default search URL would expand to something like this if you searched for schools with "art" in their name:

```
/search/?name=art&degree=2..3&sort=2011.earnings.6_yrs_after_entry.percent_greater_than_25000%3Adesc
```

Now it expands to just:

```
/search/?name=art&sort=advantage:desc
```

Along the way I also fixed some slider-related bugs and ensure that they all work as expected, with the notable exception of monthly loan payment, the data for which is currently missing from the API (cc @ultrasaurus). Here's what changed:

- The Actual Cost slider now maxes out at $90k, since the highest value in the data was about $85k. The handles move in $1k increments.
- Median Earnings now maxes out at $250k, which is the max that I found in the data.
- Monthly Payments maxes out at $1k, but we'll probably need to revisit this when the dev data is re-indexed by @ultrasaurus.