### PR TITLE
Only load open schools

### DIFF
--- a/js/picc.js
+++ b/js/picc.js
@@ -381,6 +381,8 @@
     LOCALE:               'school.locale',
     REGION_ID:            'school.region_id',
 
+    OPERATING:            '2013.student.operating',
+
     SIZE:                 '2013.student.size',
     DISTANCE_ONLY:        'school.DISTANCEONLY',
 

--- a/js/search.js
+++ b/js/search.js
@@ -83,6 +83,9 @@
 
     var query = picc.form.prepareParams(params);
 
+    // only get open schools
+    query[picc.fields.OPERATING] = 1;
+
     // only query the fields that we care about
     query.fields = [
       // we need the id to link it


### PR DESCRIPTION
This resolves #449 by adding `2013.student.operating=1` to the API request parameters for every search.