### PR TITLE
Adds share `mailto` to results and individual school pages

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -211,9 +211,9 @@ button,
 .share {
   @extend .button;
   @extend .button-primary;
-  @include font-size($h5);
+  @include font-size(0.75);
   letter-spacing: 1px;
-  padding: 6px 9px;
+  padding: 2px 7px;
   height: auto !important;
   width: auto !important;
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -207,3 +207,13 @@ button,
   font-weight: $weight-bold;
   line-height: 1;
 }
+
+.share {
+  @extend .button;
+  @extend .button-primary;
+  @include font-size($h5);
+  letter-spacing: 1px;
+  padding: 6px 9px;
+  height: auto !important;
+  width: auto !important;
+}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -213,7 +213,7 @@ button,
   @extend .button-primary;
   @include font-size(0.75);
   letter-spacing: 1px;
-  padding: 2px 7px;
+  padding: 2px 10px;
   height: auto !important;
   width: auto !important;
 }

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -86,6 +86,11 @@
   }
 }
 
+.results-share {
+  @extend .share;
+  float: right;
+}
+
 .results-filter {
   background-color: $white;
   display: none;

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -34,7 +34,7 @@
 }
 
 .results-main-alert {
-  padding-top: $base-padding-large;
+  padding-top: $base-padding-lite;
   padding-right: $base-padding;
   padding-left: $base-padding;
 
@@ -88,7 +88,15 @@
 
 .results-share {
   @extend .share;
-  float: right;
+}
+
+.results-share-wrapper {
+  @include span-columns(12);
+  text-align: right;
+
+  @include respond-to(medium-up) {
+    padding-right: $base-padding;
+  }
 }
 
 .results-filter {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -123,6 +123,8 @@
   }
 
   .school-map {
+    border: 1px solid $black;
+    border-radius: $base-border-radius;
     height: 280px;
     margin-top: $base-padding;
     @include respond-to(medium-up) {
@@ -470,4 +472,13 @@ ol.bars {
       padding-right: 0.5em;
     }
   }
+}
+
+.school-share {
+  @extend .share;
+}
+
+.school-share-wrapper {
+  @include span-columns(12);
+  text-align: right;
 }

--- a/js/picc.js
+++ b/js/picc.js
@@ -687,6 +687,19 @@
     return value === 'NULL' ? null : value;
   };
 
+  picc.template = function(template) {
+    template = String(template);
+    return function(data) {
+      return template.replace(/{\s*(\w+)\s*}/g, function(_k, key) {
+        return picc.access(key)(data);
+      });
+    };
+  };
+
+  picc.template.resolve = function(template, data) {
+    return picc.template(template).call(this, data);
+  };
+
   // namespace for school-related stuff
   picc.school = {};
 
@@ -720,6 +733,15 @@
         link: {
           text: access(fields.NAME),
           '@href': href
+        }
+      },
+
+      share_link: {
+        '@href': function(d) {
+          return picc.template.resolve(
+            this.getAttribute('data-href'),
+            {url: document.location.href}
+          );
         }
       },
 

--- a/js/search.js
+++ b/js/search.js
@@ -136,6 +136,14 @@
     // update the URL
     history.pushState(params, 'search', '?' + qs);
 
+    d3.select('a.results-share')
+      .attr('href', function() {
+        return picc.template.resolve(
+          this.getAttribute('data-href'),
+          {url: document.location.href}
+        );
+      });
+
     if (req) req.cancel();
 
     var list = d3.select(resultsRoot)

--- a/school/index.html
+++ b/school/index.html
@@ -41,6 +41,11 @@ body_scripts:
         </div>
 
         <div class="show-loaded">
+
+          <div class="school-share-wrapper">
+            <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="school-share">Share this school</a>
+          </div>
+
           <div class="school-heading">
 
             <div class="investigation-major-wrapper"

--- a/school/index.html
+++ b/school/index.html
@@ -43,7 +43,7 @@ body_scripts:
         <div class="show-loaded">
 
           <div class="school-share-wrapper">
-            <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="school-share">Share this school</a>
+            <a data-href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3%0A%0A{url}" class="school-share" data-bind="share_link">Share this school</a>
           </div>
 
           <div class="school-heading">

--- a/school/index.html
+++ b/school/index.html
@@ -43,7 +43,7 @@ body_scripts:
         <div class="show-loaded">
 
           <div class="school-share-wrapper">
-            <a data-href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3%0A%0A{url}" class="school-share" data-bind="share_link">Share this school</a>
+            <a data-href="mailto:?subject=Check%20this%20out&amp;body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3%0A%0A{url}" class="school-share" data-bind="share_link">Share this school</a>
           </div>
 
           <div class="school-heading">

--- a/search/index.html
+++ b/search/index.html
@@ -35,6 +35,8 @@ body_scripts:
 
       <div class="results-main-alert">
 
+        <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="results-share">Share</a>
+
         <div class="container show-loading">
           <h1>Loading...</h1>
         </div>
@@ -53,7 +55,7 @@ body_scripts:
             </h1>
 
           </div>
-          <!-- <a href="#search-form" class="link-more"><i class="fa fa-chevron-left"></i> Edit Criteria</a> -->
+
           <div>
 
             <div class="u-group_inline">

--- a/search/index.html
+++ b/search/index.html
@@ -36,7 +36,7 @@ body_scripts:
       <div class="results-main-alert">
 
         <div class="results-share-wrapper">
-          <a data-href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20%0A%0A{url}" class="results-share">Share</a>
+          <a data-href="mailto:?subject=Check%20this%20out&amp;body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20%0A%0A{url}" class="results-share">Share</a>
         </div>
 
         <div class="container show-loading">

--- a/search/index.html
+++ b/search/index.html
@@ -36,7 +36,7 @@ body_scripts:
       <div class="results-main-alert">
 
         <div class="results-share-wrapper">
-          <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="results-share">Share</a>
+          <a data-href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20%0A%0A{url}" class="results-share">Share</a>
         </div>
 
         <div class="container show-loading">

--- a/search/index.html
+++ b/search/index.html
@@ -35,7 +35,9 @@ body_scripts:
 
       <div class="results-main-alert">
 
-        <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="results-share">Share</a>
+        <div class="results-share-wrapper">
+          <a href="mailto:?subject=Check%20this%20out&body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%20LINK%20URL" class="results-share">Share</a>
+        </div>
 
         <div class="container show-loading">
           <h1>Loading...</h1>


### PR DESCRIPTION
Addresses #201 

Adds share button that has the beginnings of a `mailto` to the results page and the individual school pages.

Also adds a thin border around the map as with the toner tiles its sometimes hard to see where the map is, especially now that the share button is right above it.

@shawnbot I believe the only thing left is to insert the current url into the mailto, but would appreciate another eye on that mailto generally.

<img width="1015" alt="screen shot 2015-08-24 at 8 27 14 pm" src="https://cloud.githubusercontent.com/assets/4827522/9458165/2d3e7304-4aa0-11e5-8fec-d51a9b96301a.png">

<img width="891" alt="screen shot 2015-08-24 at 8 37 30 pm" src="https://cloud.githubusercontent.com/assets/4827522/9458166/2f45e452-4aa0-11e5-889e-b8f92728ae76.png">
