### PR TITLE
Make results cards all the same height

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -137,6 +137,11 @@ button,
   &:focus {
     color: $darker-green;
   }
+
+  i {
+    @include font-size(0.7);
+    padding-left: 2px;
+  }
 }
 
 // Other type

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -201,6 +201,7 @@
 
     h1 {
       @include font-size(1.4);
+      min-height: 100px;
       padding-top: 0;
 
       a[href] {

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -167,7 +167,7 @@
 
       h2.figure-heading {
         @include font-size(0.75);
-        min-height: 54px;
+        //min-height: 54px;
         &.constrain_width {
           margin-left: -5%;
           width: 110%;
@@ -189,7 +189,7 @@
   .link-more {
     @include span-columns(12 of 12);
     border-top: $thin-border-size solid $base-border-color;
-    margin-top: $base-padding;
+    margin-top: ($base-padding * 1.6);
     padding-top: $base-padding;
   }
 }
@@ -201,7 +201,6 @@
 
     h1 {
       @include font-size(1.4);
-      min-height: 100px;
       padding-top: 0;
 
       a[href] {
@@ -225,10 +224,8 @@
 
   ul {
     @include font-size(0.9);
-    border-bottom: $thin-border-size solid $base-border-color;
     font-weight: bold;
-    margin-bottom: $base-padding;
-    padding-bottom: $base-padding;
+    //padding-bottom: $base-padding;
   }
 
   h1 {
@@ -249,4 +246,10 @@
     @include span-columns(4);
     @include omega(3n);
   }
+}
+
+.results-card-headings {
+  min-height: 150px;
+  border-bottom: $thin-border-size solid $base-border-color;
+  margin-bottom: $base-padding;
 }

--- a/school/index.html
+++ b/school/index.html
@@ -122,7 +122,7 @@ body_scripts:
 
             <figure class="meter above_is_good">
               <h2 class="figure-heading constrain_width" aria-describedby="tip-avg-cost-year">
-                Salary<br/>10 Years After
+                Salary 10 Years After
                 <a class="tooltip-target u-new_line">
                   <i class="fa fa-info-circle"></i>
                 </a>

--- a/search/index.html
+++ b/search/index.html
@@ -159,7 +159,7 @@ body_scripts:
               <figure class="meter">
                 <h2 class="figure-heading constrain_width"
                   aria-describedby="tip-avg-salary">
-                  Salary<br>10 Years After
+                  Salary 10 Years After
                   <a class="tooltip-target u-new_line">
                     <i class="fa fa-info-circle"></i>
                   </a>

--- a/search/index.html
+++ b/search/index.html
@@ -106,24 +106,26 @@ body_scripts:
               </a>
             </div>
 
-            <h1 data-bind="title"><a class="link">School Name</a></h1>
-            <ul class="school-info">
-              <li class="location">
-                <span data-bind="city">City</span>,
-                <span data-bind="state">State</span>
-              </li>
-              <!-- <li class="institution-category">
-                <span data-bind="years">year category</span>
-              </li> -->
-              <li>
-                <span data-bind="size_number">x</span> undergraduate students
-              </li>
-              <!-- <a data-bind="under_investigation2" aria-hidden="true">
-                <li class="investigation-minor" aria-describedby="tip-investigation-minor">
-                  Under investigation <i class="tooltip-target fa fa-info-circle"></i>
+            <div class="results-card-headings">
+              <h1 data-bind="title"><a class="link">School Name</a></h1>
+              <ul class="school-info">
+                <li class="location">
+                  <span data-bind="city">City</span>,
+                  <span data-bind="state">State</span>
                 </li>
-              </a> -->
-            </ul>
+                <!-- <li class="institution-category">
+                  <span data-bind="years">year category</span>
+                </li> -->
+                <li>
+                  <span data-bind="size_number">x</span> undergraduate students
+                </li>
+                <!-- <a data-bind="under_investigation2" aria-hidden="true">
+                  <li class="investigation-minor" aria-describedby="tip-investigation-minor">
+                    Under investigation <i class="tooltip-target fa fa-info-circle"></i>
+                  </li>
+                </a> -->
+              </ul>
+            </div>
 
             <div id="key-stats" class="school-meters">
               <figure class="meter">

--- a/search/index.html
+++ b/search/index.html
@@ -95,6 +95,7 @@ body_scripts:
         <div class="results-main-schools schools-list container" data-bind="results">
 
           <!-- this element is the template for the results listing -->
+
           <div class="school results-card">
 
             <div class="investigation-major-wrapper"
@@ -131,7 +132,7 @@ body_scripts:
               <figure class="meter">
                 <h2 class="figure-heading constrain_width"
                   aria-describedby="tip-avg-cost-year">
-                  Average Actual Cost
+                  Average <br>Actual Cost
                   <a class="tooltip-target u-new_line">
                     <i class="fa fa-info-circle"></i>
                   </a>
@@ -146,7 +147,7 @@ body_scripts:
               <figure class="meter">
                 <h2 class="figure-heading constrain_width"
                   aria-describedby="tip-graduation-rate">
-                  Graduation Rate
+                  Graduation <br>Rate
                   <a class="tooltip-target u-new_line">
                     <i class="fa fa-info-circle"></i>
                   </a>
@@ -161,7 +162,7 @@ body_scripts:
               <figure class="meter">
                 <h2 class="figure-heading constrain_width"
                   aria-describedby="tip-avg-salary">
-                  Salary 10 Years After
+                  Salary 10 <br>Years After
                   <a class="tooltip-target u-new_line">
                     <i class="fa fa-info-circle"></i>
                   </a>


### PR DESCRIPTION
This PR makes results cards all the same height, as per #335. This solution only works with school names that stay on three lines, but we decided this would cover the vast majority of schools.

This also includes outstanding spacing and typography bugs on the cards.

![screen shot 2015-08-25 at 8 17 21 am](https://cloud.githubusercontent.com/assets/4827522/9471112/b4d56922-4b03-11e5-8f3e-3dde9426080a.png)
