### PR TITLE
Fix tooltip overflow inside <aria-accordion> elements

### DIFF
--- a/_sass/base/components/_aria-accordion.scss
+++ b/_sass/base/components/_aria-accordion.scss
@@ -5,8 +5,9 @@ aria-accordion {
   @include transition(height 1s linear);
 
   display: block;
-  overflow: hidden;
   min-height: $button-size + ($button-margin * 2);
+  // overflow: hidden;
+
   @include respond-to(tiny-up) {
     min-height: $button-size + ($button-margin * 3);
   }
@@ -18,10 +19,10 @@ aria-accordion {
   }
 
   [aria-controls]:after {
-    color: #999;
     background: #fff;
     border: 1px solid #e3e3e3;
     border-radius: 500px;
+    color: #999;
     display: inline-block;
     font-size: $button-size;
     font-weight: normal;


### PR DESCRIPTION
This PR removes `overflow: hidden` from the `<aria-accordion>` styles, which resolves the tooltip overlap issues described in #463.