### PR TITLE
added instructions on how to install java

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -32,6 +32,8 @@ For local testing you'll need [Selenium Server][Selenium Server]
 [webdriver-manager]:
 
 ```sh
+# install java
+brew cask install java
 # install the package
 npm install -g webdriver-manager
 # run the command line tool to install Selenium Server


### PR DESCRIPTION
I added instructions on how to install java with brew cask. When I installed Java in the traditional "installer from Oracle" way it didn't work for webdriver-manager.