### PR TITLE
Fix school share link

### DIFF
--- a/js/picc.js
+++ b/js/picc.js
@@ -757,7 +757,7 @@
         '@href': function(d) {
           return picc.template.resolve(
             this.getAttribute('data-href'),
-            {url: document.location.href}
+            {url: encodeURIComponent(document.location.href)}
           );
         }
       },

--- a/js/search.js
+++ b/js/search.js
@@ -122,7 +122,7 @@
       .attr('href', function() {
         return picc.template.resolve(
           this.getAttribute('data-href'),
-          {url: document.location.href}
+          {url: encodeURIComponent(document.location.href)}
         );
       });
 

--- a/school/index.html
+++ b/school/index.html
@@ -43,7 +43,7 @@ body_scripts:
         <div class="show-loaded">
 
           <div class="school-share-wrapper">
-            <a data-href="mailto:?subject=Check%20this%20out&amp;body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3%0A%0A{url}" class="school-share" data-bind="share_link">Share this school</a>
+            <a data-href="mailto:?subject=Check%20this%20out&amp;body=I%20found%20this%20on%20collegescorecard.ed.gov,%20check%20it%20out%3A%0A%0A{url}" class="school-share" data-bind="share_link">Share this school</a>
           </div>
 
           <div class="school-heading">


### PR DESCRIPTION
This will resolve #201.

@meiqimichelle the problem with the link was that one of my URL-encoded line breaks (`%3A`) was missing its `A`, so the browser failed to parse it. I added a safeguard to also encode the URL itself, just in case other browsers are more strict about this type of thing.