### PR TITLE
Re-add national averages for sliders

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -36,7 +36,10 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="$" max="90000" step="1000">
+          <picc-slider format="$"
+            average="{{ site.data.national_stats.net_price.median }}"
+            max="{{ site.data.national_stats.net_price.max }}"
+            step="1000">
             <input type="hidden" name="avg_net_price">
           </picc-slider>
         </div>
@@ -48,7 +51,8 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="%" step=".01" max="1">
+          <picc-slider format="%" step=".01" max="1"
+            average="{{ site.data.national_stats.completion_rate.median }}">
             <input type="hidden" name="completion_rate">
           </picc-slider>
         </div>
@@ -59,7 +63,10 @@
               <i class="fa fa-info-circle"></i>
             </a>
           </h2>
-          <picc-slider format="$" max="250000">
+          <picc-slider format="$"
+            average="{{ site.data.national_stats.median_earnings.median }}"
+            max="{{ site.data.national_stats.median_earnings.max }}"
+            step="1000">
             <input type="hidden" name="median_earnings">
           </picc-slider>
         </div>


### PR DESCRIPTION
This resolves #473 by re-introducing the overall national averages for net price, graduation rate and median salary to the corresponding filter sliders on the search page:

![image](https://cloud.githubusercontent.com/assets/113896/9486628/8a0ac2c0-4b7e-11e5-9f6d-32d0465a69e8.png)
