### PR TITLE
Meter line width

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -44,7 +44,7 @@ $yellow: #f0d704;
 $darker-yellow: #eeba28;
 $red: #d44116;
 $darker-red: #b93610;
-$purple: #5c48c9;
+$purple: #8c57f6;
 $amethyst-purple: #9384e9;
 
 $black-transparent: rgba(0, 0, 0, 0.8);

--- a/_sass/base/components/_legend.scss
+++ b/_sass/base/components/_legend.scss
@@ -17,8 +17,8 @@ $nat_average-height: 25px;
 }
 
 .legend-nat_average-box-line {
-  border-bottom: $thin-border-size solid $black;
-  height: ($nat_average-height * 0.42);
+  border-bottom: 2px solid $black;
+  height: ($nat_average-height * 0.48);
 }
 
 .legend-nat_average-words {

--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -27,20 +27,6 @@ picc-meter {
     bottom: 0%;
     transition: bottom .5s;
 
-    &:after {
-      content: "";
-      display: block;
-      width: 100%;
-      position: absolute;
-      top: 100%;
-      height: 50%;
-      left: 0;
-      right: 0;
-      background-color: #fff;
-      opacity: 0;
-      transition: opacity .5s;
-    }
-
     .label {
       height: 1em;
       left: 100%;
@@ -48,12 +34,6 @@ picc-meter {
       position: absolute;
       margin: -.4em 0 0 8px;
       // border: 1px dotted red;
-    }
-  }
-
-  &.above_average {
-    .picc-meter-line:after {
-      opacity: 1;
     }
   }
 

--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -21,7 +21,7 @@ picc-meter {
     left: 0;
     right: 0;
     bottom: 0;
-    height: 3px;
+    height: 2px;
     background-color: #000;
     background-color: rgba(0,0,0,.8);
     bottom: 0%;


### PR DESCRIPTION
Changes the width of the meter average line and the national average line to be the same at 2 px instead of 3 and 1, previously. Addresses #556.


![screen shot 2015-08-26 at 7 09 35 am](https://cloud.githubusercontent.com/assets/4827522/9495802/2f149302-4bc2-11e5-85c5-e5f30ee8a44a.png)


