### PR TITLE
Add map tile attribution

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -503,3 +503,8 @@ ol.bars {
   @include span-columns(12);
   text-align: right;
 }
+
+.leaflet-control-attribution a {
+  text-decoration: underline;
+  color: $black !important;
+}

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -505,6 +505,6 @@ ol.bars {
 }
 
 .leaflet-control-attribution a {
-  text-decoration: underline;
   color: $black !important;
+  text-decoration: underline;
 }

--- a/js/school.js
+++ b/js/school.js
@@ -194,6 +194,13 @@
     L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png')
       .addTo(map);
 
+    L.control.attribution({
+        position: 'bottomleft',
+        prefix: false
+      })
+      .addAttribution('Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.<br>Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.')
+      .addTo(map);
+
     var marker = L.circle(center, 1200, {
         color: 'black',
         opacity: 1,


### PR DESCRIPTION
Stamen's tiles (and the underlying OSM data) are licensed under [Creative Commons Attribution](http://creativecommons.org/licenses/by/3.0/), which means that they have to include attribution. I've styled the attribution minimally:

![image](https://cloud.githubusercontent.com/assets/113896/9501682/85cf744a-4be1-11e5-9aa9-7cea80ccb87f.png)
