### PR TITLE
Add meter "No data available" state

### DIFF
--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -49,4 +49,16 @@ picc-meter {
     }
   }
 
+  &.no_data {
+    &:after {
+      @include font-size(.8);
+      color: $dark-gray;
+      content: 'Data not available';
+      display: block;
+      padding: 3em .5em;
+      position: relative;
+      text-align: center;
+    }
+  }
+
 }

--- a/_sass/base/components/_picc-meter.scss
+++ b/_sass/base/components/_picc-meter.scss
@@ -55,7 +55,8 @@ picc-meter {
       color: $dark-gray;
       content: 'Data not available';
       display: block;
-      padding: 3em .5em;
+      line-height: 1.2;
+      padding: 60% .5em 0;
       position: relative;
       text-align: center;
     }

--- a/js/components/picc-meter.js
+++ b/js/components/picc-meter.js
@@ -33,44 +33,69 @@
         update: {value: function() {
           var min = this.min;
           var max = this.max;
-
-          var scale = function(v) {
-            return (v - min) / (max - min);
-          };
-
-          var percent = function(v) {
-            return (scale(v) * 100).toFixed(1) + '%';
-          };
+          var value = this.value;
+          var average = this.average;
 
           var bar = getBar(this);
-          // prevent the bar from exceeding the height
-          var value = Math.min(this.value, this.max);
-          bar.style.setProperty('height', percent(value));
-
           var line = getLine(this);
 
-          var average = this.average;
-          var difference;
-          // console.log('average:', this.getAttribute('average'), '->', average);
-          if (isNaN(average)) {
+          if (typeof value !== 'number' || isNaN(value)) {
+            // console.log('bad value:', value);
+
+            // reset the bar
+            bar.style.setProperty('display', 'none');
+            bar.style.removeProperty('height');
+
+            // reset the line
             line.style.setProperty('display', 'none');
+            line.style.removeProperty('bottom');
+
+            // classify and bail
             classify(this, {
+              'no_data': true,
               'above_average': false,
               'below_average': false,
               'about_average': false
             });
-          } else {
-            difference = value - average;
-            line.style.removeProperty('display');
-            line.style.setProperty('bottom', percent(this.average));
-            var aboutThreshold = getAttr(this, 'about-threshold', .05) * (this.max - this.min);
-            classify(this, {
-              'above_average': difference > 0,
-              'below_average': difference < 0,
-              'about_average': Math.abs(difference) <= aboutThreshold
-            });
-          }
 
+          } else {
+
+            classify(this, {no_data: false});
+
+            var scale = function(v) {
+              return (v - min) / (max - min);
+            };
+
+            var percent = function(v) {
+              return (scale(v) * 100).toFixed(1) + '%';
+            };
+
+            bar.style.removeProperty('display');
+            // prevent the bar from exceeding the height
+            bar.style.setProperty('height', percent(Math.min(value, max)));
+
+            var difference;
+            // console.log('average:', this.getAttribute('average'), '->', average);
+            if (isNaN(average)) {
+              line.style.setProperty('display', 'none');
+              classify(this, {
+                'above_average': false,
+                'below_average': false,
+                'about_average': false
+              });
+            } else {
+              difference = value - average;
+              line.style.removeProperty('display');
+              line.style.setProperty('bottom', percent(this.average));
+              var aboutThreshold = getAttr(this, 'about-threshold', .05) * (max - min);
+              classify(this, {
+                'above_average': difference > 0,
+                'below_average': difference < 0,
+                'about_average': Math.abs(difference) <= aboutThreshold
+              });
+            }
+
+          }
 
           delete this.__timeout;
 

--- a/js/picc.js
+++ b/js/picc.js
@@ -609,6 +609,18 @@
     );
   };
 
+  /*
+  // XXX this version of the median earnings accessor stringifies a
+  // numeric earnings value so that the old version of tagalong
+  // we're using doesn't treat 0 as empty
+  picc.access.earningsMedian = function(d) {
+    var value = picc.access(picc.fields.MEDIAN_EARNINGS)(d);
+    return typeof value === 'number'
+      ? String(value)
+      : value;
+  };
+  */
+
   picc.access.earningsMedian = picc.access.composed(
     picc.fields.MEDIAN_EARNINGS
   );


### PR DESCRIPTION
This PR introduces a "no data" state to the `<picc-meter>` component, which looks like this in the search results:

![image](https://cloud.githubusercontent.com/assets/113896/9509016/0096506c-4c10-11e5-9c20-c8d81c100b12.png)

and like this on the school pages:

![image](https://cloud.githubusercontent.com/assets/113896/9509022/0dc0aaf8-4c10-11e5-95e4-bf24f5417c90.png)

There are some weird issues with `0` values (as opposed to `null`), but I think this gets us most of the way there. It seems like for most of the meters, anyway, that `0` should be interpreted as `null`.