### PR TITLE
Tweak zip code search parameters

### DIFF
--- a/js/picc.js
+++ b/js/picc.js
@@ -1130,8 +1130,16 @@
       },
 
       state:                fields.STATE,
-      zip:                  fields.ZIP_CODE,
       online:               fields.ONLINE_ONLY,
+
+      zip: function(query, value, key) {
+        if (query.distance) {
+          return;
+        } else {
+          query[fields.ZIP_CODE] = value;
+          delete query[key];
+        }
+      },
 
       control: function(query, value, key) {
         value = mapControl(value);

--- a/js/picc.js
+++ b/js/picc.js
@@ -1133,12 +1133,14 @@
       online:               fields.ONLINE_ONLY,
 
       zip: function(query, value, key) {
-        if (query.distance) {
-          return;
-        } else {
+        // if there is no distance query, use the explicit `school.zip` field
+        // to match schools in that zip code
+        if (!query.distance) {
           query[fields.ZIP_CODE] = value;
           delete query[key];
         }
+        // (the default will submit `zip=x&distance=y`,
+        // which is what the API expects)
       },
 
       control: function(query, value, key) {


### PR DESCRIPTION
This PR changes the behavior of the zip code input on the search page so that:

1. If a zip code is supplied with a distance, the query string parameter is named `zip`, because I think this is hard-coded in the API (can you confirm, @ultrasaurus?). ([test url][test distance])
2. If a zip code is suppled *without* a distance, the query string parameter is named `school.zip` so it matches the specific field. ([test url][test zip])

[test distance]: https://federalist.18f.gov/preview/18F/college-choice/fix-distance-search/search/?zip=10002&distance=20
[test zip]: https://federalist.18f.gov/preview/18F/college-choice/fix-distance-search/search/?zip=10002