### PR TITLE
Test score chart tweaks

### DIFF
--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -269,6 +269,14 @@ ol.disc,
   float: right;
 }
 
+.no-data {
+  color: $dark-gray;
+  border: 1px solid $light-gray;
+  border-radius: $base-border-radius;
+  padding: $base-padding-lite $base-padding !important;
+  margin-top: $base-padding;
+  margin-bottom: $base-padding;
+}
 
 // Lower an element below its container
 //

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -273,7 +273,7 @@ ol.disc,
   color: $dark-gray;
   border: 1px solid $light-gray;
   border-radius: $base-border-radius;
-  padding: $base-padding-lite $base-padding !important;
+  padding: $base-padding-lite ($base-padding-lite * 2) !important;
   margin-top: $base-padding;
   margin-bottom: $base-padding;
 }

--- a/_sass/base/components/_picc-range.scss
+++ b/_sass/base/components/_picc-range.scss
@@ -29,6 +29,7 @@ picc-range {
     transition: left .5s;
 
     span {
+      font-weight: 200;
       position: absolute;
       top: $label-height;
       width: $label-width;
@@ -51,13 +52,17 @@ picc-range {
     &.picc-range-label-middle,
     &.picc-range-label-lower,
     &.picc-range-label-upper {
-      border: 1px solid black;
+      border-left: 1px solid black;
+    }
+
+    &.picc-range-label-upper {
+      border-left: none;
+      border-right: 1px solid black;
     }
 
     &.picc-range-label-min,
     &.picc-range-label-max,
     &.picc-range-label-middle {
-      border-width: 2px;
       bottom: -.5em;
       top: auto;
 

--- a/_sass/base/components/_picc-range.scss
+++ b/_sass/base/components/_picc-range.scss
@@ -54,16 +54,23 @@ picc-range {
       border: 1px solid black;
     }
 
+    &.picc-range-label-min,
+    &.picc-range-label-max,
     &.picc-range-label-middle {
       border-width: 2px;
-      bottom: 0;
+      bottom: -.5em;
       top: auto;
 
       span {
         bottom: 100%;
+        top: auto;
+      }
+    }
+
+    &.picc-range-label-middle {
+      span {
         margin-left: -($label-width / 2);
         text-align: center;
-        top: auto;
       }
     }
   }

--- a/js/components/picc-range.js
+++ b/js/components/picc-range.js
@@ -25,9 +25,9 @@
 
           this.min = getAttr(this, 'min', 0);
           this.max = getAttr(this, 'max', 1);
-          this.lower = getAttr(this, 'lower', 0);
-          this.middle = getAttr(this, 'middle', 0);
-          this.upper = getAttr(this, 'upper', 0);
+          this.lower = getAttr(this, 'lower');
+          this.middle = getAttr(this, 'middle');
+          this.upper = getAttr(this, 'upper');
 
           this.update();
         }},
@@ -67,10 +67,15 @@
             if (!label) return;
 
             var value = this[type];
-            label.style.setProperty('left', percent(value));
-            var span = label.querySelector('span');
-            if (span) {
-              span.textContent = String(Math.round(value));
+            if (typeof value !== 'number' || isNaN(value)) {
+              label.style.setProperty('display', 'none');
+            } else {
+              label.style.removeProperty('display');
+              label.style.setProperty('left', percent(value));
+              var span = label.querySelector('span');
+              if (span) {
+                span.textContent = String(Math.round(value));
+              }
             }
           }, this);
 
@@ -92,7 +97,7 @@
             return this.__max;
           },
           set: function(value) {
-            this.__max = number(value, 0);
+            this.__max = number(value);
             deferUpdate(this);
           }
         },
@@ -102,7 +107,7 @@
             return this.__lower;
           },
           set: function(value) {
-            this.__lower = number(value, 0);
+            this.__lower = number(value);
             deferUpdate(this);
           }
         },
@@ -112,7 +117,7 @@
             return this.__middle;
           },
           set: function(value) {
-            this.__middle = number(value, 0);
+            this.__middle = number(value);
             deferUpdate(this);
           }
         },
@@ -122,7 +127,7 @@
             return this.__upper;
           },
           set: function(value) {
-            this.__upper = number(value, 0);
+            this.__upper = number(value);
             deferUpdate(this);
           }
         }
@@ -148,7 +153,7 @@
 
   function number(value, fallback) {
     var num = +value;
-    return isNaN(value) ? (fallback || 0) : num;
+    return isNaN(value) ? fallback : num;
   }
 
   function classify(el, classes) {

--- a/js/picc.js
+++ b/js/picc.js
@@ -339,10 +339,17 @@
         //'4': 'Graduate'
       }, NA)),
 
-      zero: function(key) {
+      empty: function(key) {
         key = picc.access(key);
         return function(d) {
-          return key.call(this, d) == 0;
+          return !key.call(this, d);
+        };
+      },
+
+      notEmpty: function(key) {
+        key = picc.access(key);
+        return function(d) {
+          return !!key.call(this, d);
         };
       },
 
@@ -983,39 +990,51 @@
       },
 
       act_scores_visible: {
-        '@aria-hidden': format.zero(fields.ACT_MIDPOINT),
+        '@aria-hidden': format.empty(fields.ACT_MIDPOINT),
+      },
+      act_scores_invisible: {
+        '@aria-hidden': format.notEmpty(fields.ACT_MIDPOINT),
       },
       act_scores: {
         '@lower': access(fields.ACT_25TH_PCTILE),
         '@upper': access(fields.ACT_75TH_PCTILE),
-        '@middle': access(fields.ACT_MIDPOINT),
+        // '@middle': access(fields.ACT_MIDPOINT),
       },
 
       sat_reading_scores_visible: {
-        '@aria-hidden': format.zero(fields.SAT_READING_MIDPOINT),
+        '@aria-hidden': format.empty(fields.SAT_READING_MIDPOINT),
+      },
+      sat_reading_scores_invisible: {
+        '@aria-hidden': format.notEmpty(fields.SAT_READING_MIDPOINT),
       },
       sat_reading_scores: {
         '@lower': access(fields.SAT_READING_25TH_PCTILE),
         '@upper': access(fields.SAT_READING_75TH_PCTILE),
-        '@middle': access(fields.SAT_READING_MIDPOINT),
+        // '@middle': access(fields.SAT_READING_MIDPOINT),
       },
 
       sat_math_scores_visible: {
-        '@aria-hidden': format.zero(fields.SAT_MATH_MIDPOINT),
+        '@aria-hidden': format.empty(fields.SAT_MATH_MIDPOINT),
+      },
+      sat_math_scores_invisible: {
+        '@aria-hidden': format.notEmpty(fields.SAT_MATH_MIDPOINT),
       },
       sat_math_scores: {
         '@lower': access(fields.SAT_MATH_25TH_PCTILE),
         '@upper': access(fields.SAT_MATH_75TH_PCTILE),
-        '@middle': access(fields.SAT_MATH_MIDPOINT),
+        // '@middle': access(fields.SAT_MATH_MIDPOINT),
       },
 
       sat_writing_scores_visible: {
-        '@aria-hidden': format.zero(fields.SAT_WRITING_MIDPOINT),
+        '@aria-hidden': format.empty(fields.SAT_WRITING_MIDPOINT),
+      },
+      sat_writing_scores_invisible: {
+        '@aria-hidden': format.notEmpty(fields.SAT_WRITING_MIDPOINT),
       },
       sat_writing_scores: {
         '@lower': access(fields.SAT_WRITING_25TH_PCTILE),
         '@upper': access(fields.SAT_WRITING_75TH_PCTILE),
-        '@middle': access(fields.SAT_WRITING_MIDPOINT),
+        // '@middle': access(fields.SAT_WRITING_MIDPOINT),
       },
 
       net_price_calculator: {

--- a/school/index.html
+++ b/school/index.html
@@ -597,18 +597,27 @@ body_scripts:
                       <picc-range data-bind="sat_reading_scores" max="800">
                       </picc-range>
                     </figure>
+                    <p class="no-data" data-bind="sat_reading_scores_invisible">
+                      No Critical Reading data available.
+                    </p>
 
                     <figure data-bind="sat_math_scores_visible">
                       <h4>Math</h4>
                       <picc-range data-bind="sat_math_scores" max="800">
                       </picc-range>
                     </figure>
+                    <p class="no-data" data-bind="sat_math_scores_invisible">
+                      No Math data available.
+                    </p>
 
                     <figure data-bind="sat_writing_scores_visible">
                       <h4>Writing</h4>
                       <picc-range data-bind="sat_writing_scores" max="800">
                       </picc-range>
                     </figure>
+                    <p class="no-data" data-bind="sat_writing_scores_invisible">
+                      No Writing data available.
+                    </p>
 
                     <h3 class="h2">ACT</h3>
 
@@ -616,6 +625,10 @@ body_scripts:
                       <picc-range data-bind="act_scores" min="0" max="36">
                       </picc-range>
                     </figure>
+                    <p class="no-data" data-bind="act_scores_invisible">
+                      No data available.
+                    </p>
+
                   </div>
 
                   <!-- </div> -->


### PR DESCRIPTION
This addresses a couple of issues related to the SAT and ACT charts:

* Removes midpoint (median) scores per #102 (via #382)
* Min/max label overlaps: #666 
* Style adjustments per #344 (sans the average scores, which are no longer visible)
* Adds basic "no data" display for SAT & ACT scores per #528