### PR TITLE
Copy change: "Calculate your personal net price"

### DIFF
--- a/school/index.html
+++ b/school/index.html
@@ -185,7 +185,7 @@ body_scripts:
 
                     <a class="button button-primary" target="_blank" data-bind="net_price_calculator">
                       <i class="fa fa-calculator"></i>
-                      Calculate your exact net price
+                      Calculate your personal net price
                     </a>
 
                   </div>


### PR DESCRIPTION
Suggest changing "Calculate your exact net price" to "calculate your personal net price."  A college's net price calculator can't give an individual his/her exact net price, but it can give a personal estimate.