### PR TITLE
Fix school name in map popup

### DIFF
--- a/js/school.js
+++ b/js/school.js
@@ -211,7 +211,7 @@
       })
       .addTo(map);
 
-    marker.bindPopup(school.name);
+    marker.bindPopup(school.school.name);
     return map;
   }
 


### PR DESCRIPTION
The marker pop up on the map for the school wasn't grabbing the school name from the right place.