### PR TITLE
Fix repayment rate national average

### DIFF
--- a/_data/national_stats.yaml
+++ b/_data/national_stats.yaml
@@ -50,7 +50,7 @@ retention_rate_l4:
   min: 0
   max: 1
   median: 0.60
-repayment_rate_4:
+repayment_rate:
   min: 0.05
   max: 1
   median: 0.70


### PR DESCRIPTION
The overall `repayment_rate` key in `national_stats.yaml` had an errant `_4` suffix on it. This will address #753.

![image](https://cloud.githubusercontent.com/assets/113896/9569832/3fb5595e-4f2c-11e5-8bec-fd87b7b118ee.png)
