### PR TITLE
IE11 and interaction fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ sass:
 # common site scripts, relative to `{{ site.baseurl }}/js/`
 scripts:
   - vendor/aight.min.js
+  - compat/custom-event.js
   - vendor/d3.min.js
   - vendor/async.min.js
   - vendor/querystring.min.js

--- a/_sass/base/components/_tooltip.scss
+++ b/_sass/base/components/_tooltip.scss
@@ -92,3 +92,7 @@
     }
   }
 }
+
+body.dragging [role="tooltip"] {
+  visibility: hidden;
+}

--- a/js/compat/custom-event.js
+++ b/js/compat/custom-event.js
@@ -1,0 +1,24 @@
+(function() {
+
+  try {
+    new CustomEvent('foo');
+  } catch (err) {
+
+    var createEvent = document.createCustomEvent || document.createEvent;
+
+    window.CustomEvent = function(event, params) {
+      var evt;
+      params = params || {
+        bubbles: false,
+        cancelable: false,
+        detail: undefined
+      };
+      evt = createEvent.call(document, 'CustomEvent');
+      evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+      return evt;
+    };
+
+    window.CustomEvent.prototype = window.Event.prototype;
+  }
+
+})(this);

--- a/js/components/aria-accordion.js
+++ b/js/components/aria-accordion.js
@@ -4,22 +4,6 @@
   var HIDDEN = 'aria-hidden';
   var TOGGLE_EVENTS = ['click', 'touchstart'];
 
-  // because PhantomJS and oldIE don't implement CustomEvent
-  if (!window.CustomEvent) {
-    window.CustomEvent = function(event, params) {
-      var evt;
-      params = params || {
-        bubbles: false,
-        cancelable: false,
-        detail: undefined
-      };
-      evt = document.createEvent("CustomEvent");
-      evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
-      return evt;
-    };
-    window.CustomEvent.prototype = window.Event.prototype;
-  }
-
   exports.ARIAAccordion = document.registerElement('aria-accordion', {
     prototype: Object.create(
       HTMLElement.prototype,

--- a/js/components/picc-slider.js
+++ b/js/components/picc-slider.js
@@ -24,16 +24,15 @@
       this.addEventListener('click', click);
       this.addEventListener('mousedown', engage);
       this.addEventListener('touchstart', engage);
-      this.addEventListener('focus', focus, true);
+      // this.addEventListener('focus', engage, true);
       this.update();
     },
 
     detachedCallback: function() {
-      // console.log('picc-slider detached');
       this.removeEventListener('click', click);
       this.removeEventListener('mousedown', enagage);
       this.removeEventListener('touchstart', enagage);
-      this.removeEventListener('focus', focus, true);
+      // this.removeEventListener('focus', engage, true);
     },
 
     attributeChangedCallback: function(attr, prev, value) {
@@ -170,34 +169,34 @@
 
   function click(e) {
     // ignore right-clicks
-    if (e.button === 2) return false;
-    // console.log('click');
+    if (e.button === 2) return;
+    // console.info('* click');
     this.__dragging = getClosestHandle.call(this, e);
-    this.__dragging.setAttribute('aria-grabbed', true);
     move.call(this, e);
-    release.call(this, e);
+    this.__dragging = null;
+    this.dispatchEvent(new CustomEvent('change'));
   }
 
   function engage(e) {
-    if (this.__dragging) {
-      console.warn('already dragging on engage()');
-      return;
-    }
-
     // ignore right-clicks
     if (e.button === 2) {
       e.preventDefault();
       return;
     }
-    // console.log('+ engage');
+    // console.info('+ engage', e.type);
 
     this.__dragging = getClosestHandle.call(this, e);
     this.__dragging.setAttribute('aria-grabbed', true);
 
-    window.addEventListener('mousemove', getListener(move, this));
-    window.addEventListener('mouseup', getListener(release, this));
-    window.addEventListener('touchmove', getListener(move, this));
-    window.addEventListener('touchend', getListener(release, this));
+    if (e.type === 'focus') {
+      window.addEventListener('keyup', getListener(keypress, this));
+      this.addEventListener('blur', release, true);
+    } else {
+      window.addEventListener('mousemove', getListener(move, this));
+      window.addEventListener('mouseup', getListener(release, this));
+      window.addEventListener('touchmove', getListener(move, this));
+      window.addEventListener('touchend', getListener(release, this));
+    }
   }
 
   function move(e) {
@@ -206,7 +205,7 @@
       return;
     }
 
-    // console.log('* move');
+    // console.info('* move', e.type);
 
     var handle = this.__dragging;
     var x = getMouseX.call(this, e);
@@ -239,7 +238,8 @@
   }
 
   function release(e) {
-    // console.log('- release');
+    // console.info('- release', e.type);
+
     if (this.__dragging) {
       this.__dragging.removeAttribute('aria-grabbed');
     } else {
@@ -249,10 +249,15 @@
     this.__dragging = false;
     this.removeAttribute('aria-valuenow');
 
-    window.removeEventListener('mousemove', getListener(move, this));
-    window.removeEventListener('mouseup', getListener(release, this));
-    window.removeEventListener('touchmove', getListener(move, this));
-    window.removeEventListener('touchend', getListener(release, this));
+    if (e.type === 'blur') {
+      window.removeEventListener('keyup', getListener(keypress, this));
+      this.removeEventListener('blur', release, true);
+    } else {
+      window.removeEventListener('mousemove', getListener(move, this));
+      window.removeEventListener('mouseup', getListener(release, this));
+      window.removeEventListener('touchmove', getListener(move, this));
+      window.removeEventListener('touchend', getListener(release, this));
+    }
 
     this.dispatchEvent(new CustomEvent('change'));
 
@@ -261,7 +266,7 @@
   }
 
   function keypress(e) {
-    // console.log('* keypress:', e.keyCode);
+    // console.info('* keypress:', e.keyCode);
     switch (e.keyCode) {
       case 37: // left
         nudge.call(this, -1);
@@ -284,28 +289,10 @@
     }
   }
 
-  function focus(e) {
-    // console.log('+ focus');
-    this.__dragging = e.target;
-    this.__dragging.setAttribute('aria-grabbed', true);
-
-    window.addEventListener('keyup', getListener(keypress, this));
-    this.addEventListener('blur', blur, true);
-  }
-
-  function blur(e) {
-    if (this.__dragging === e.target) {
-      // console.log('- blur');
-      release.call(this, e);
-      window.removeEventListener('keyup', getListener(keypress, this));
-      this.removeEventListener('blur', blur, true);
-    } else {
-      // console.log('# invalid blur');
-    }
-  }
-
   function getListener(fn, obj) {
-    var key = '__' + fn.name;
+    var name = fn.name || fn.toString().match(/function (\w+)/)[1];
+    var key = '__listener_' + name;
+    // console.log('listener:', name);
     return obj[key] || (obj[key] = fn.bind(obj));
   }
 
@@ -388,8 +375,9 @@
     }
 
     var x = getMouseX.call(this, e);
-    var left = this.__left.getBoundingClientRect().right;
+    var left = this.__left.getBoundingClientRect().left;
     var right = this.__right.getBoundingClientRect().left;
+    // console.info('x: %d, left: %d, right: %d', x, left, right);
     var dl = Math.abs(x - left);
     var dr = Math.abs(x - right);
     return dl < dr ? this.__left : this.__right;
@@ -398,7 +386,10 @@
   function getMouseX(e) {
     var rect = this.getBoundingClientRect();
     var width = rect.width;
-    return e.clientX - rect.left;
+    var x = (e.touches && e.touches.length)
+      ? e.touches[0].clientX
+      : e.clientX;
+    return x - rect.left;
   }
 
   function nudge(multiplier) {
@@ -408,11 +399,6 @@
     var property = handle === this.__left ? 'lower' : 'upper';
     var step = this.step || .1;
     this[property] += step * multiplier;
-  }
-
-  function getCenter(el) {
-    var rect = el.getBoundingClientRect();
-    return rect.left; // + rect.width / 2;
   }
 
   function clamp(x, min, max) {

--- a/js/picc.js
+++ b/js/picc.js
@@ -1605,12 +1605,12 @@
   });
 
   window.addEventListener('mousedown', function(e) {
-    console.info('+ drag');
+    // console.info('+ drag');
     document.body.classList.add('dragging');
   });
 
   window.addEventListener('mouseup', function(e) {
-    console.info('- drag');
+    // console.info('- drag');
     document.body.classList.remove('dragging');
   });
 

--- a/js/picc.js
+++ b/js/picc.js
@@ -1364,6 +1364,7 @@
     return function() {
       var context = this;
       var args = arguments;
+      clearTimeout(timeout);
       return timeout = setTimeout(function() {
         fn.apply(context, args);
       }, delay);

--- a/js/picc.js
+++ b/js/picc.js
@@ -1604,4 +1604,14 @@
     );
   });
 
+  window.addEventListener('mousedown', function(e) {
+    console.info('+ drag');
+    document.body.classList.add('dragging');
+  });
+
+  window.addEventListener('mouseup', function(e) {
+    console.info('- drag');
+    document.body.classList.remove('dragging');
+  });
+
 })(this);

--- a/js/search.js
+++ b/js/search.js
@@ -142,7 +142,7 @@
         );
       });
 
-    if (req) req.cancel();
+    if (req) req.abort();
 
     var list = d3.select(resultsRoot)
       .select('[data-bind="results"]');
@@ -160,7 +160,7 @@
 
     console.time && console.time('[load]');
 
-    picc.API.search(query, function(error, data) {
+    req = picc.API.search(query, function(error, data) {
       resultsRoot.classList.remove('js-loading');
       list.classed('hidden', false);
 

--- a/js/search.js
+++ b/js/search.js
@@ -11,6 +11,9 @@
   // not any of the other elements (results total, sort, pages)
   var incremental = false;
 
+  // if this flag is set to false, the search form will not resubmit
+  var submit = true;
+
   // the maximum # of page links to show
   var MAX_PAGES = 6;
 
@@ -65,6 +68,10 @@
     incremental = true;
   });
 
+  form.on('change:_drawer', function(value, e) {
+    submit = false;
+  });
+
   form.on('submit', function(data, e) {
     change();
     e.preventDefault();
@@ -79,7 +86,16 @@
   });
 
   function onChange() {
+    if (!submit) {
+      // console.warn('not submitting this time!');
+      submit = true;
+      return;
+    }
+
     var params = form.getData();
+
+    // don't submit the _drawer parameter
+    delete params._drawer;
 
     var query = picc.form.prepareParams(params);
 

--- a/search/index.html
+++ b/search/index.html
@@ -11,18 +11,14 @@ body_scripts:
   - search.js
 ---
 
-{% assign show_search_filters = true %}
-{% assign search_form_nested = true %}
-
 <form id="search-form" is="search-form"
   autocomplete="false"
   action="{{ page.permalink }}" method="GET" class="drawer">
 
-
-
-  <input type="checkbox" id="drawer-toggle">
+  <input type="checkbox" id="drawer-toggle" name="_drawer">
   <label for="drawer-toggle" id="drawer-toggle-label"></label>
   <header><span>Filter and edit your search</span></header>
+
   <nav id="drawer">
 
     <div>


### PR DESCRIPTION
This PR will address #901, #851, #900 (#844), and #894.

Thankfully, most of the problems boiled down to a flaw in the [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) polyfill that I included in `aria-accordion.js`. So most of the work here involves moving that out into a separate script, `compat/custom-event.js`, which uses IE's proprietary `document.createCustomEvent()` if available. With custom events working, accordions open and close and charts update without issue.

:warning: The fix for #901 involved adding a flag that disables search form resubmission when the drawer is toggled. It doesn't work 100% of the time, but the flag is only set to `false` when the drawer toggle changes, then it's set back to `true` for the next change. This seems solid to me, but I could use another pair of eyes on the JS to make sure I haven't introduced a regression that could prevent the form from submitting.

:warning: There was a (sadly) flawed assumption in my implementation of idempotent event listeners and IE's implementation of `Function.prototype.name`, so I added an [ugly hack](https://github.com/18F/college-choice/commit/7e1b1a57880e65f2cf8e2df55574710050bcfe1a#diff-8ae6b20515be0f32fae079288e61d8d8R293) that stringifies the function and gets its name from a regular expression match.

:+1: This PR also fixes some previously undiscovered issues with the search submission process, which was *supposed* to be canceling outbound requests when inputs changed before they were loaded but wasn't. `picc.debounce()` also wasn't clearing timeouts, which was dumb. (See commit 4567d1f for more info.) Touch events on sliders were also broken, and are fixed in 996570e.