### PR TITLE
Under investigation

### DIFF
--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -259,6 +259,12 @@
 
   @include respond-to(large-up) {
     @include omega-reset(2n);
+    @include span-columns(4);
+    @include omega(3n);
+  }
+
+  @include respond-to(huge-up) {
+    @include omega-reset(3n);
     @include span-columns(3);
     @include omega(4n);
   }

--- a/_sass/base/components/_under-investigation.scss
+++ b/_sass/base/components/_under-investigation.scss
@@ -5,9 +5,10 @@
   text-transform: uppercase;
 }
 
-$invest_height: 36px;
+$invest_height: 32px;
 
 .investigation-major {
+  @include font-size(0.9);
   @extend .light_on_dark;
   color: $white;
   font-weight: $weight-bold;

--- a/js/picc.js
+++ b/js/picc.js
@@ -450,7 +450,7 @@
     MINORITY_SERVING:     'school.minority_serving',
 
     PREDOMINANT_DEGREE:   'school.degrees_awarded.predominant',
-    UNDER_INVESTIGATION:  'school.HCM2',
+    UNDER_INVESTIGATION:  'school.under_investigation',
 
     // net price
     NET_PRICE:            '2013.cost.avg_net_price.overall',


### PR DESCRIPTION
- Fixes missing 'under investigation label' that got accidentally removed with some API naming changes.
- Polishes 'under investigation' UI to account for new card widths
- Makes cards move from 4-up to 3-up and then 2-up per row sooner so we don't have super-skinny cards on the 4-up view. This also helps with the 'under investigation' display.

This addresses #943