### PR TITLE
Changes background of special designations to light blue

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -197,14 +197,13 @@ button,
 }
 
 .special {
-  background-color: #f6e768;
+  background-color: #d3eefb;
   display: inline-block;
   font-weight: 600;
   line-height: 1;
   margin-right: $base-padding-lite;
   margin-bottom: 0.2em;
   padding: 0.3em;
-  text-transform: uppercase;
 }
 
 .fact_number {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -73,14 +73,16 @@
 
   .school-heading {
     h1 {
+      @include font-size($h1-huge);
       padding-bottom: $base-padding-lite;
     }
 
     h2 {
+      color: $dark-gray;
       margin-top: 0;
       margin-bottom: 0;
       padding-top: 0;
-      font-size: font-size($h4);
+      font-size: font-size($h1);
       font-weight: normal;
     }
 


### PR DESCRIPTION
Changes background of special designations to light blue as per #723 . Fixes incorrect heading sizes in passing as per #941.

<img width="873" alt="screen shot 2015-09-01 at 11 57 55 am" src="https://cloud.githubusercontent.com/assets/4827522/9613561/fab4f8a2-50a0-11e5-84b5-1e092f7209a3.png">
