### PR TITLE
Add browser compatibilty message

### DIFF
--- a/_layouts/default-data.html
+++ b/_layouts/default-data.html
@@ -3,6 +3,16 @@
   {% include head.html %}
   <body>
     {% include header-data.html %}
+
+    <!--[if lt IE 10]>
+    <div class="compat-message">
+      <div class="container">
+        <h1>We&rsquo;re sorry. The browser version you are using is not
+          supported.<br>Please update your browser to the latest version.</h1>
+      </div>
+    </div>
+    <![endif]-->
+    
     <main>
       {{ content }}
     </main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,8 @@
     <!--[if lt IE 10]>
     <div class="compat-message">
       <div class="container">
-        <h1>Hi, your browser is old.</h1>
+        <h1>We&rsquo;re sorry. The browser version you are using is not
+          supported.<br>Please update your browser to the latest version.</h1>
       </div>
     </div>
     <![endif]-->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,14 @@
   <body data-env="{{ site.branch }}">
     {% include header.html %}
 
+    <!--[if lt IE 10]>
+    <div class="compat-message">
+      <div class="container">
+        <h1>Hi, your browser is old.</h1>
+      </div>
+    </div>
+    <![endif]-->
+
     <main>
       {{ content }}
     </main>

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -24,6 +24,7 @@
 @import 'typography';
 
 // Components
+@import 'components/browser-compat';
 @import 'components/buttons';
 @import 'components/drawer';
 @import 'components/figures';

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -284,3 +284,9 @@ ol.disc,
 .u-lower {
   margin-bottom: -5em !important;
 }
+
+.compat-message {
+  background: #ffe;
+  color: $red;
+  padding: $base-padding 0;
+}

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -284,9 +284,3 @@ ol.disc,
 .u-lower {
   margin-bottom: -5em !important;
 }
-
-.compat-message {
-  background: #ffe;
-  color: $red;
-  padding: $base-padding 0;
-}

--- a/_sass/base/components/_browser-compat.scss
+++ b/_sass/base/components/_browser-compat.scss
@@ -1,0 +1,5 @@
+.compat-message {
+  background: #ffe;
+  color: $red;
+  padding: $base-padding 0;
+}


### PR DESCRIPTION
Per #455. It looks like this, and shows up in IE≤9:

![image](https://cloud.githubusercontent.com/assets/113896/9619266/05770aba-50c3-11e5-8bac-c0c3b91ebf60.png)
