### PR TITLE
Check the "include online only schools" box by default

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -117,7 +117,7 @@
         </div>
 
         <label for="online" class="checkbox">
-          <input id="online" type="checkbox" name="online" value="1" tabindex="0">
+          <input id="online" type="checkbox" name="online" checked value="1" tabindex="0">
           <span tabindex="-1" class="checkbox-focus"></span>Include Online Only Schools
         </label>
 


### PR DESCRIPTION
This addresses the final requirement in #490 by checking the "Include Online Only Schools" box by default.

**Please note:**

1. This results in an additional parameter added to the URL query string (`&online=1`) by default.
1. Old search URLs that do not include this flag *will now be rewritten to include it*, which will change search result totals.

Mostly this is for @LisaGee and @hollyallen, who I'm pretty sure are expecting certain counts to match.