### PR TITLE
High-priority visual bug fixes

### DIFF
--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -6,7 +6,7 @@
 
       <legend>Programs/Degree</legend>
       <h1 class="search_category">
-        <a aria-expanded="true" aria-controls="major-content">
+        <a aria-expanded="false" aria-controls="major-content">
           Programs/Degree
         </a>
       </h1>

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -48,12 +48,14 @@
   li {
     border-bottom: $thin-border-size solid $base-border-color;
     display: inline-block;
-    margin: $base-padding $base-padding-extra;
-    padding-bottom: $base-padding;
+    margin: $base-padding $base-padding-lite;
+    padding-bottom: $base-padding-large;
     vertical-align: top;
 
-    @include respond-to(tiny-up) {
+    @include respond-to(small-up) {
       border-bottom: none;
+      margin: $base-padding $base-padding-extra;
+      padding-bottom: $base-padding;
     }
 
     &:last-of-type {

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -270,7 +270,7 @@
 .search_form-submit {
   @extend .centered;
   border-top: $thick-border-size solid $base-border-color;
-  padding-top: $base-padding-extra;
+  padding-top: $base-padding-large;
   padding-right: 0;
   padding-left: 0;
   text-align: center;
@@ -281,7 +281,7 @@
 }
 
 .search-button {
-  margin-bottom: $base-padding-extra;
+  margin-bottom: $base-padding-large;
   width: 80% !important;
 
   @include respond-to(medium-up) {

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -221,7 +221,6 @@
 
   @include respond-to(small-up) {
     background: url(../img/hero.jpg) center center no-repeat;
-    background-attachment: fixed;
     background-size: cover;
   }
 }

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -160,7 +160,7 @@
 
 .results-main {
   background-color: $mid-gray;
-  min-height: 900px; //TODO make this auto
+  //min-height: 900px;
 }
 
 .results-main-schools {
@@ -171,18 +171,16 @@
   }
 
   .school-meters {
-    overflow: hidden;
-
     figure.meter {
       @include span-columns(4 of 12);
       @include omega(3n);
 
       figcaption {
-        @include font-size(1);
+        @include font-size(0.9);
       }
 
       h2.figure-heading {
-        @include font-size(0.75);
+        @include font-size(0.7);
         &.constrain_width {
           margin-left: -5%;
           width: 110%;
@@ -215,7 +213,7 @@
     border-radius: 0;
 
     h1 {
-      @include font-size(1.4);
+      @include font-size($h1);
       padding-top: 0;
 
       a[href] {
@@ -238,7 +236,7 @@
   padding: $base-padding;
 
   ul {
-    @include font-size(0.9);
+    @include font-size($h4);
     font-weight: bold;
   }
 
@@ -270,7 +268,7 @@
 }
 
 .results-card-headings {
-  min-height: 150px;
+  min-height: 160px;
   border-bottom: $thin-border-size solid $base-border-color;
   margin-bottom: $base-padding;
 }

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -526,9 +526,6 @@
   margin-top: $base-padding-extra;
 
   .fact_number {
-    border: $regular-border-size solid $base-border-color;
-    border-radius: 500px;
-    height: 120px;
     padding-top: 31px;
     text-align: center;
     width: 120px;
@@ -543,6 +540,11 @@
   width: 75%;
   margin-left: auto;
   margin-right: auto;
+  margin-bottom: $base-padding-lite;
+
+  .fact_number {
+    display: inline-block;
+  }
 }
 
   // @include span-columns(12);

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -230,11 +230,19 @@
 
     > div {
       border-top: $thin-border-size solid $base-border-color;
-      padding-top: $base-padding-lite;
+      padding-top: $base-padding-large;
+      padding-bottom: $base-padding-large;
 
       &:first-of-type {
         border-top: none;
-        padding-top: 0;
+
+        @include respond-to(small-up) {
+          padding-top: 0;
+        }
+
+        p {
+          padding-bottom: 0;
+        }
       }
     }
 
@@ -248,16 +256,24 @@
     }
   }
 
+  strong.fact_number {
+    font-weight: $weight-bold;
+
+  }
+
   .fact_number {
     @include font-size(3.5);
+    font-weight: normal;
 
     padding: {
       top: 8px;
       bottom: 8px;
     }
 
+    + strong {
+    }
+
     span {
-      font-weight: normal;
 
       &.small {
         @include font-size(1.8);
@@ -373,7 +389,7 @@
   @include span-columns(5 fo 5);
   background-color: $sky-blue-light;
   border-radius: $base-border-radius;
-  margin-top: $base-padding;
+  margin-top: $base-padding-extra;
   padding-top: $base-padding;
   padding-bottom: $base-padding;
 }

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -85,10 +85,6 @@
     margin-bottom: 0;
   }
 
-  .legend-wrapper + .button {
-    margin-top: $base-padding;
-  }
-
   .school-heading {
     h1 {
       @include font-size($h1);
@@ -289,6 +285,18 @@
     width: 100%;
   }
 
+  .button-costs {
+    margin-top: $base-padding-large;
+    margin-bottom: $base-padding-large;
+    padding-left: $base-padding-large;
+    padding-right:  $base-padding-large;
+    width: 100%;
+
+    @include respond-to(large-up) {
+      width: 300px;
+    }
+  }
+
   .school-two_col {
 
     p {
@@ -318,12 +326,13 @@
   }
 
   .school-two_col-right {
-    padding-top: $base-padding;
+    padding-top: $base-padding-large;
 
     @include span-columns(6 of 6);
     @include respond-to(large-up) {
       @include span-columns(3 of 6);
       @include omega();
+      padding-top: $base-padding;
     }
   }
 }
@@ -549,7 +558,7 @@
   margin-top: $base-padding-extra;
 
   .fact_number {
-    padding-top: 31px;
+    padding-top: 0;
     text-align: center;
     width: 120px;
 

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -486,14 +486,21 @@
 
 .school-student-stats-col {
 
-  .test-align {
-    width: 75%;
+  .school-student-stats-col-align {
+    display: inline-block;
     margin-right: auto;
     margin-left: auto;
+    text-align: center;
+    width: 85%;
 
     > div {
       display: inline-block;
+      text-align: left;
       vertical-align: middle;
+
+      &:last-of-type {
+        padding-left: $base-padding-lite;
+      }
     }
   }
 

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -91,8 +91,12 @@
 
   .school-heading {
     h1 {
-      @include font-size($h1-huge);
+      @include font-size($h1);
       padding-bottom: $base-padding-lite;
+
+      @include respond-to(small-up) {
+        @include font-size($h1-huge);
+      }
     }
 
     h2 {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -378,9 +378,18 @@
   padding-bottom: $base-padding;
 }
 
+.average-value {
+  display: block;
+}
+
+.average-wrapper {
+  display: inline-block;
+  padding-bottom: $base-padding-lite;
+}
+
 .above_is_good .average.above_average,
 .below_is_good .average.below_average {
-  color: $green;
+  color: $lime-green;
 }
 
 .above_is_good .average.below_average,
@@ -393,8 +402,9 @@
 }
 
 .average-label {
-  font-size: .5em;
-  font-weight: normal;
+  @include font-size($h5);
+  font-weight: $weight-bold;
+  text-transform: uppercase;
 }
 
 .school-student-intro {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -100,11 +100,11 @@
     }
 
     h2 {
-      color: $dark-gray;
+      color: $black;
       margin-top: 0;
       margin-bottom: 0;
       padding-top: 0;
-      font-size: font-size($h1);
+      font-size: font-size($h2);
       font-weight: normal;
     }
 

--- a/index.html
+++ b/index.html
@@ -51,10 +51,6 @@ layout: default
 
       <h1>By the Numbers</h1>
 
-      <!-- <a class="link-more">
-        More Key Facts <i class="fa fa-chevron-right"></i>
-      </a> -->
-
       <ul>
         <li>
           <img src="{{ site.baseurl }}/img/money.svg" alt="Dollar bills">

--- a/school/index.html
+++ b/school/index.html
@@ -524,7 +524,7 @@ stylesheets:
 
                       <div class="school-student-stats-col">
 
-                        <div class="test-align">
+                        <div class="school-student-stats-col-align">
 
                           <div>
                             <span class="fact_number">

--- a/school/index.html
+++ b/school/index.html
@@ -178,9 +178,10 @@ stylesheets:
                       <picc-meter id="cost-meter" {% include net_price_meter_attributes.html %}>
                       </picc-meter>
                       <figcaption>
-                        <i class="fa average average-arrow" data-meter="cost-meter"></i>
-                        <span data-bind="average_cost"></span>
-                        <div class="average average-label"></div>
+                        <span class="average-value" data-bind="average_cost"></span>
+                        <div class="average-wrapper">
+                          <i class="fa average average-arrow" data-meter="cost-meter"></i> <span class="average average-label"></span>
+                        </div>
                       </figcaption>
                     </figure>
 
@@ -274,11 +275,15 @@ stylesheets:
                         data-median-four_year="{{ site.data.national_stats.repayment_rate_4.median }}"
                         data-median-lt_four_year="{{ site.data.national_stats.repayment_rate_l4.median }}">
                       </picc-meter>
+
                       <figcaption>
-                        <i class="fa average average-arrow" data-meter="repayment-meter"></i>
-                        <span data-bind="repayment_rate_percent">XX%</span>
-                        <div class="average average-label"></div>
+                        <span class="average-value" data-bind="repayment_rate_percent">XX%</span>
+                        <div class="average-wrapper">
+                          <i class="fa average average-arrow" data-meter="repayment-meter"></i> <span class="average average-label"></span>
+                        </div>
                       </figcaption>
+
+
                     </figure>
 
                     <div class="legend-wrapper">
@@ -372,9 +377,10 @@ stylesheets:
                       <picc-meter id="grad-meter" {% include graduation_meter_attributes.html %}>
                       </picc-meter>
                       <figcaption>
-                        <i class="fa average average-arrow" data-meter="grad-meter"></i>
-                        <span data-bind="grad_rate">60%</span>
-                        <div class="average average-label"></div>
+                        <span class="average-value" data-bind="grad_rate">60%</span>
+                        <div class="average-wrapper">
+                          <i class="fa average average-arrow" data-meter="grad-meter"></i> <span class="average average-label"></span>
+                        </div>
                       </figcaption>
                     </figure>
 
@@ -406,9 +412,10 @@ stylesheets:
                         average-range="{{ site.data.national_stats.retention_rate.average_range|join:'..' }}">
                       </picc-meter>
                       <figcaption>
-                        <i class="fa average average-arrow" data-meter="retention-meter"></i>
-                        <span data-bind="retention_rate_value">XX%</span>
-                        <div class="average average-label"></div>
+                        <span class="average-value" data-bind="retention_rate_value">XX%</span>
+                        <div class="average-wrapper">
+                          <i class="fa average average-arrow" data-meter="retention-meter"></i> <span class="average average-label"></span>
+                        </div>
                       </figcaption>
                     </figure>
 
@@ -462,9 +469,10 @@ stylesheets:
                       <picc-meter id="salary-meter" {% include earnings_meter_attributes.html %}>
                       </picc-meter>
                       <figcaption>
-                        <i class="fa average average-arrow" data-meter="salary-meter"></i>
-                        <span data-bind="average_salary">$XX,XXX</span>
-                        <div class="average average-label"></div>
+                        <span class="average-value" data-bind="average_salary">$XX,XXX</span>
+                        <div class="average-wrapper">
+                          <i class="fa average average-arrow" data-meter="salary-meter"></i> <span class="average average-label"></span>
+                        </div>
                       </figcaption>
                     </figure>
 

--- a/school/index.html
+++ b/school/index.html
@@ -521,26 +521,7 @@ stylesheets:
                   <div class="school-two_col school-student-body">
 
                     <div class="school-two_col-left">
-                      <!-- FIXME Gender Data Missing
-                      <h2
-                        aria-describedby="tip-graduation-rate">Gender
-                        <a class="tooltip-target">
-                          <i class="fa fa-info-circle"></i>
-                        </a>
-                      </h2>
-                      <ol class="bars" data-bind="gender_values">
-                        {% include bar_chart_template_item.html %}
-                      </ol>
-                    -->
-                      <!-- <div class="school-student-stats"> -->
-                      <!--
-                      <h2
-                        aria-describedby="tip-graduation-rate">Other Demographics
-                        <a class="tooltip-target">
-                          <i class="fa fa-info-circle"></i>
-                        </a>
-                      </h2>
-                    -->
+
                       <div class="school-student-stats-col">
 
                         <div class="test-align">
@@ -563,39 +544,19 @@ stylesheets:
 
                         <div class="school-student-socio_econ">
                           <h2>Socio-Economic Diversity</h2>
-                          <div class="group_inline school-student-socio_econ-stat">
-                            <div class="group_inline-left">
-                              <strong class="fact_number" data-bind="pell_grant_percentage">X</strong>
-                            </div>
-                            <div class="group_inline-right">
-                              <strong>of students</strong>
-                            </div>
+
+                          <div class="school-student-socio_econ-stat">
+                            <strong class="fact_number" data-bind="pell_grant_percentage">X</strong>
+                            <strong>of students</strong>
                           </div>
-                          <p>have a family income less than $40k and receive a
-                            grant to pay for college.</p>
+
+                          <p>have a family income less than $40k and receive a grant to pay for college.</p>
                         </div>
 
-                        <!-- <div class="school-student-stat group_inline">
-                          <h2>Socio-Economic Diversity</h2>
-                          <strong class="fact_number big">
-                            <strong data-bind="pell_grant_percentage">XX%</strong>
-                            <span class="small normal">of students</span>
-                          </strong>
-                          <p>have a family income less than $40k and receive a
-                            grant to pay for college.</p>
-                        </div> -->
-
-<!--
-                        <div class="group_inline">
-                          <div class="group_inline-left"><span class="fact_number" data-bind="age_entry">XX</span></div>
-                          <div class="group_inline-right"><p class="school-student-stats-col-p">Average age at enrollment</p></div>
-                        </div>
--->
                       </div>
 
                     </div>
 
-                    <!-- </div> -->
 
                     <div class="school-two_col-right">
                       <h2
@@ -612,38 +573,6 @@ stylesheets:
 
                   </div>
 
-                  <!-- <div class="school-student-stats">
-                    <h2>Other Demographics</h2>
-
-                    <div class="school-student-stats-col">
-                      <div>
-                        <span class="fact_number">
-                          <strong data-bind="full_time_percent">XX</strong>
-                          <span class="small">%</span>
-                        </span> Full-time
-                      </div>
-                      <div class="fact_number divide">/</div>
-                      <div>
-                        <span class="fact_number">
-                          <strong data-bind="part_time_percent">XX</strong>
-                          <span>%</span>
-                        </span> Part-time
-                      </div>
-                    </div>
-
-                    <div class="school-student-stats-col">
-                      <div class="group_inline">
-                        <div class="group_inline-left"><span class="fact_number" data-bind="age_entry">XX</span></div>
-                        <div class="group_inline-right"><p class="school-student-stats-col-p">Average age at enrollment</p></div>
-                      </div>
-                    </div> -->
-
-                    <!-- <div class="school-student-stats-col"> -->
-                      <!-- Placeholder for future stats -->
-                    <!-- </div> -->
-
-                  <!-- </div> -->
-
                 </div>
               </div>
             </aria-accordion>
@@ -659,19 +588,7 @@ stylesheets:
                 </h1>
 
                 <div id="selectivity-content" aria-hidden="true">
-                  <!-- <div class="school-two_col-left centered">
-                    <h2
-                      aria-describedby="tip-graduation-rate">
-                      Acceptance Rate
-                      <a class="tooltip-target">
-                        <i class="fa fa-info-circle"></i>
-                      </a>
-                    </h2>
-                    <strong class="fact_number">Somewhat Selective</strong>
-                    <p>[chart here]</p>
-                  </div> -->
 
-                  <!-- <div class="school-two_col-right"> -->
                   <div style="padding-top: 20px;"> <!--TODO-->
                     <h2
                       aria-describedby="tip-test-scores">
@@ -723,7 +640,6 @@ stylesheets:
 
                   </div>
 
-                  <!-- </div> -->
                 </div>
               </div>
             </aria-accordion>
@@ -740,11 +656,6 @@ stylesheets:
 
                 <div id="academics-content" aria-hidden="true">
                   <div class="school-two_col-left">
-
-                    <!-- <div class="school-academics-fact group_inline">
-                      <div class="group_inline-left"><strong class="fact_number" data-bind="num_available_programs">X</strong></div>
-                      <div class="group_inline-right"><h2><span data-bind="programs_plural">Programs</span> Offered</h2></div>
-                    </div> -->
 
                     <h2
                       aria-describedby="tip-pop-prog">

--- a/school/index.html
+++ b/school/index.html
@@ -510,7 +510,7 @@ stylesheets:
                       </li>
                       <li class="school-key_figures-stat">
                         <div class="group_inline">
-                          <div class="group_inline-left fact_number" data-bind="size_number">X,XXX</div>
+                          <strong class="group_inline-left fact_number" data-bind="size_number">X,XXX</strong>
                           <div class="group_inline-right"><p>undergraduate <br>students</p></div>
                         </div>
                       </li>

--- a/school/index.html
+++ b/school/index.html
@@ -195,7 +195,7 @@ stylesheets:
                       </div>
                     </div>
 
-                    <a class="button button-primary" target="_blank" data-bind="net_price_calculator">
+                    <a class="button button-primary button-costs" target="_blank" data-bind="net_price_calculator">
                       <i class="fa fa-calculator"></i>
                       Calculate your personal net price
                     </a>

--- a/search/index.html
+++ b/search/index.html
@@ -107,8 +107,6 @@ permalink: /search/
                   <option value="completion_rate:desc">Graduation Rate</option>
                   <option value="salary:desc">Salary After School</option>
                   <option value="name:asc">Name (A to Z)</option>
-                  <!--option value="name:desc">Name (Z to A)</option -->
-                  <!--option value="size:desc">Size (large to small)</option-->
                   <option value="size:asc">Size (small to large)</option>
                 </select>
               </div>
@@ -152,7 +150,7 @@ permalink: /search/
                     <span data-bind="state">State</span>
                   </li>
                   <li>
-                    <span data-bind="size_number">x</span> undergraduate students
+                    <span data-bind="size_number">x</span> undergraduates
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
@jjoteal These are the high-priority visual bug fixes from our list, minus the data tool. I'll do the data ones in a separate PR so we can start reviewing these live on `dev`

- Closes all search fields on home by default #1051
- Makes homepage background image scroll with the rest of the site #1022
- Makes indiv school title sizes smaller #1039 
- Reduces padding around form submit button #1021
- Adjusts positioning of arrow in the higher/lower than average displays, and adjusts styles on the words #433 
- Removes circle around socio-econ and adjusts full/part-time student display. #925 and #425
- Changes color and size of h2 in indiv school headings #1032 
- Confirms text treatment on results cards. Changes 'undergraduate students' to 'undergraduates' so the text doesn't have to be tiny to stay on one line. #1052
- Standardizes spacing on indiv school pages. #1042 
- Fixes margin problems at small sizes in By The Numbers that was causing horizontal scroll. #1028