### PR TITLE
Medium priority visual bugs

### DIFF
--- a/_includes/bar_chart_template_item.html
+++ b/_includes/bar_chart_template_item.html
@@ -1,9 +1,10 @@
 <li>
   <span class="value" data-bind="value"></span>
-  <div class="bar"></div>
+  <div class="bar-wrapper">
+    <div class="bar"></div>
+  </div>
   <span class="text">
     <strong class="percent" data-bind="percent">XX%</strong>
     <span class="label" data-bind="label">Label</span>
   </span>
 </li>
-

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -67,10 +67,10 @@
             </div>
             <div class="u-group_inline u-group_inline-right u-nowrap">
               <button class="button button-add">
-                Add State
+                Add<br>State
               </button>
               <button class="button button-remove">
-                &times;
+                <i class="fa fa-times-circle"></i>
               </button>
             </div>
           </multi-select>
@@ -94,7 +94,7 @@
             </div>
             <div class="u-group_inline u-group_inline-right u-nowrap">
               <button class="button button-add">
-                Add Region
+                Add<br>Region
               </button>
               <button class="button button-remove">
                 &times;

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -25,6 +25,7 @@ $white: #ffffff;
 $black: #040404;
 $light-putty: #f6f6f6;
 $dark-gray: #666666;
+$mid-dark-gray: #999999;
 $mid-gray: #e1e1e1;
 $light-gray: #eaeaea;
 $lighter-gray: #eeeeee;

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -14,7 +14,6 @@ $header-font-family: $base-font-family;
 $base-font-weight: $weight-book;
 
 
-
 // Sizes
 $base-font-size: 1;
 $base-line-height: 1.5;

--- a/_sass/base/blocks/_footer.scss
+++ b/_sass/base/blocks/_footer.scss
@@ -28,23 +28,29 @@ footer {
   }
 
   .footer-attribution {
+    @include font-size(0.6);
     width: 90%;
     margin-left: auto;
     margin-right: auto;
 
     @include respond-to(tiny-up) {
+      @include font-size(0.7);
       width: 70%;
     }
 
     @include respond-to(small-up) {
-      width: 50%;
+      width: 60%;
     }
 
     @include respond-to(medium-up) {
-      width: 40%;
+      width: 50%;
     }
 
     @include respond-to(large-up) {
+      width: 40%;
+    }
+
+    @include respond-to(huge-up) {
       width: 30%;
     }
   }

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -166,7 +166,6 @@
     .button-outline {
       @include font-size($h6);
       padding-left: $base-padding;
-
       padding-right: $base-padding;
     }
 

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -156,16 +156,30 @@
   }
 
   .section-home-paying-content {
-    padding: $base-padding-extra $base-padding-large $base-padding-large $base-padding-large;
+    padding: $base-padding $base-padding-large $base-padding-large $base-padding-large;
     text-align: left;
 
     p {
       padding-bottom: $base-padding-lite;
     }
 
+    .button-outline {
+      @include font-size($h6);
+      padding-left: $base-padding;
+
+      padding-right: $base-padding;
+    }
+
+    @include respond-to(small-up) {
+      .button-outline {
+        @include font-size($h4);
+      }
+    }
+
     @include respond-to(large-up) {
       min-height: 430px;
-      //TODO this is to make this section even with the one next door
+      //TODO magic number: this is to make this section even with the one next door
+      padding-top: $base-padding-extra;
     }
   }
 

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -210,7 +210,8 @@
 .section-card_container-results {
 
   .results-card {
-    border-radius: 0;
+    border: $base-padding-lite solid $mid-gray;
+    border-radius: 1em;
 
     h1 {
       @include font-size($h1);
@@ -227,6 +228,7 @@
     }
 
     @include respond-to(small-up) {
+      border: none;
       border-radius: 0.4em;
     }
   }

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -522,6 +522,7 @@
       display: inline-block;
       text-align: left;
       vertical-align: middle;
+      white-space: nowrap;
 
       &:last-of-type {
         padding-left: $base-padding-lite;
@@ -535,8 +536,7 @@
   }
 
   .fact_number {
-    @include font-size(3);
-
+    @include font-size(2.5);
     padding-bottom: 0;
 
     .small {
@@ -546,6 +546,10 @@
     &.divide {
       @include font-size(4.2);
       color: darken($mid-gray, 10%);
+    }
+
+    @include respond-to(medium-up) {
+      @include font-size(3);
     }
   }
 

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -634,9 +634,13 @@ ol.bars {
     margin-bottom: 0.7em;
     position: relative;
 
+    .bar-wrapper {
+      background: $light-gray;
+    }
+
     .bar {
-      background: $sky-blue;
-      height: 1em;
+      background: $lime-green;
+      height: 1.2em;
     }
 
     &.bar-female .bar {

--- a/_sass/base/components/_buttons.scss
+++ b/_sass/base/components/_buttons.scss
@@ -87,10 +87,26 @@ input[type="submit"] {
   }
 
   &.button-add {
-    width: 50px;
     @extend .link-more;
     background-color: $white;
+    border-radius: 0;
     color: $green;
+    padding-right: 0;
+    padding-left: 0;
+    line-height: 1;
+
+    &:hover,
+    &:focus {
+      background-color: $white;
+      color: $darker-green;
+    }
+  }
+
+  &.button-remove {
+    @include font-size($h1-large);
+    background-color: $white;
+    color: $mid-dark-gray;
+    line-height: 1;
 
     &:hover,
     &:focus {

--- a/school/index.html
+++ b/school/index.html
@@ -543,7 +543,12 @@ stylesheets:
                         </div>
 
                         <div class="school-student-socio_econ">
-                          <h2>Socio-Economic Diversity</h2>
+                          <h2 aria-describedby="tip-socio-eco">
+                            Socio-Economic Diversity
+                            <a class="tooltip-target">
+                              <i class="fa fa-info-circle"></i>
+                            </a>
+                          </h2>
 
                           <div class="school-student-socio_econ-stat">
                             <strong class="fact_number" data-bind="pell_grant_percentage">X</strong>


### PR DESCRIPTION
This PR addresses medium priority visual bugs

- Makes full-part time stats smaller on mobile so they are less ugly. #1047 
- Gets closer to proper ethnicity chart look/feel #1034
- Adds tooltip to socio-econ header #924 
- Improves spacing of Get The Best Deal buttons on homepage at small sizes #1029 
- Reduces size of attribution in footer, and ensures that it stays on two lines at all but the teeniest screen sizes. #1088
- Matches remove state button to mock #1031 
- Gives mobile-size cards a bit of an edge so they still look like 'cards' #342 