### PR TITLE
Lower priority visual design bug fixes

### DIFF
--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -141,7 +141,7 @@
 
     .section-home-numbers-group-left {
       display: table-cell;
-      padding-right: 8px;
+      padding-right: 20px;
     }
 
     .section-home-numbers-group-right {

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -72,7 +72,7 @@
     }
 
      .fact-words {
-      max-width: 290px;
+      max-width: 280px;
       margin-left: auto;
       margin-right: auto;
     }

--- a/_sass/base/blocks/_home.scss
+++ b/_sass/base/blocks/_home.scss
@@ -70,6 +70,12 @@
       width: 100px;
       margin-bottom: $base-padding;
     }
+
+     .fact-words {
+      max-width: 290px;
+      margin-left: auto;
+      margin-right: auto;
+    }
   }
 
   span {

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -342,6 +342,10 @@
 .school-table {
   width: 100%;
 
+  th {
+    text-transform: uppercase;
+  }
+
   td, th {
     padding: em(5);
     text-align: left;

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -89,6 +89,8 @@
     h1 {
       @include font-size($h1);
       padding-bottom: $base-padding-lite;
+      margin-top: -11px;
+      //magic number to make top of text align with map
 
       @include respond-to(small-up) {
         @include font-size($h1-huge);

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -359,9 +359,9 @@
 
 .school-long_list {
   border-top: $thin-border-size solid $base-border-color;
-  height: 375px;
+  max-height: 375px;
   margin-top: $base-padding-lite;
-  overflow-y: auto;
+  overflow-y: scroll;
 
   li {
     border-bottom: $thin-border-size solid $base-border-color;

--- a/_sass/base/components/_pagination.scss
+++ b/_sass/base/components/_pagination.scss
@@ -1,10 +1,11 @@
 .pagination {
   @include span-columns(12);
-  margin-top: $base-padding;
+  margin-top: $base-padding-lite;
   margin-left: $base-padding;
 
   @include respond-to(small-up) {
     text-align: right;
+    margin-top: $base-padding;
     margin-left: 0;
   }
 

--- a/index.html
+++ b/index.html
@@ -58,8 +58,8 @@ layout: default
             On average, college graduates earn
             <strong>$1 million</strong>
             <strong>more</strong>
-            over their lifetimes than<br>
-            high school graduates.
+            <div class="fact-words">over their lifetimes than
+            high school graduates.</div>
           </div>
         </li>
         <li>
@@ -67,15 +67,15 @@ layout: default
           You could be eligible for up to
           <strong>$5,775</strong>
           <strong>for free</strong>
-          in federal grants to help pay for<br>
-          college. <span>No repayment needed!</span>
+          <div class="fact-words">in federal grants to help pay
+          for college. <span>No repayment needed!</span></div>
         </li>
         <li>
           <img src="{{ site.baseurl }}/img/cap.svg" alt="Graduation cap">
           Did you know that
           <strong>30%</strong>
           <strong>of college graduates</strong>
-          started college at <span>age 25 or older</span>.
+          <div class="fact-words">started college at <span>age 25 or older</span>.</div>
         </li>
       </ul>
 


### PR DESCRIPTION
This PR addresses lower priority visual design bugs

- Adds left-right padding to Start My Application button so it is not squished at small screen sizes (I accidentally merged this straight to `dev`, but still want to record as part of this set of bugs for review)  #1043
- Reduces padding on top of pagination at small screen sizes and moves to left. #1038
- Aligns top of indiv schools heading with map #1035
- Adds perma-scrollbar to academics list, and also makes the size of that section respond to the size of the table. #635 
- Makes costs table headings uppercase #296
- Fixes By The Numbers text flow on small screen sizes #1053 
- Adds 20px of space next to Check Out These Schools #1023