### PR TITLE
A few minor visual bug edits

### DIFF
--- a/_sass/base/blocks/_footer.scss
+++ b/_sass/base/blocks/_footer.scss
@@ -9,7 +9,7 @@ footer {
 
   @include respond-to(tiny-up) {
     @include font-size($h5);
-    height: 227px;
+    height: 215px;
     padding-top: 32px;
   }
 

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -343,6 +343,7 @@
   width: 100%;
 
   th {
+    font-weight: $weight-bold;
     text-transform: uppercase;
   }
 


### PR DESCRIPTION
From @jjoteal feedback on yesterday's visual bug work

- Make table headings bold as well as uppercase for #296 
- Reduce footer bottom margin a tad more (after we made the attribution smaller, I forgot to make the foot height smaller, too) #1024 
- Adds heading to 'earning potential' stat and adds tooltip #1033 
