### PR TITLE
"Data unavailable" sorts to the top

### DIFF
--- a/"data unavailable" sorts to the top
+++ b/"data unavailable" sorts to the top
@@ -1,0 +1,6 @@
+When sorting by "%Earning Above", schools with "Data Not Available" sort to the top
+
+Repo: search for all private schools, get 2219 results, sort by "%Earning Above" and the school at the top has "Data Not Available" 
+for the Earnings field.
+
+iPhone5 running iOS 8.4.1 using Safari


### PR DESCRIPTION

![data not available](https://cloud.githubusercontent.com/assets/12420233/9722960/0b843362-5585-11e5-8d39-e71e27ff4d65.PNG)
When sorting by "%Earning Above", schools with "Data Not Available" sort to the top.