### PR TITLE
Financial Aid section updates

### DIFF
--- a/school/index.html
+++ b/school/index.html
@@ -338,7 +338,7 @@ stylesheets:
                     <div>
                       <h2
                         aria-describedby="tip-student-aid">
-                        Students Receiving Federal Aid
+                        Students Receiving Federal Loans
                         <a class="tooltip-target">
                           <i class="fa fa-info-circle"></i>
                         </a>


### PR DESCRIPTION
This is a WIP fix for #1196 that:

1. Changes the "Students Receiving Federal Aid" figure title to "Students Receiving Federal Loans".