### PR TITLE
Fixes under investigation tooltip issue

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -13,6 +13,14 @@ $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;
 $base-font-weight: $weight-book;
 
+// z-index
+$z-under: -100;
+$z-ground: 0;
+$z-first: 100;
+$z-second: 200;
+$z-third: 300;
+$z-rooftop: 10000;
+
 
 // Sizes
 $base-font-size: 1;

--- a/_sass/base/blocks/_results.scss
+++ b/_sass/base/blocks/_results.scss
@@ -192,6 +192,7 @@
       picc-meter {
         height: 120px;
         width: 90%;
+        z-index: $z-first;
 
         // don't show labels on small meters
         .label {

--- a/_sass/base/components/_gallery.scss
+++ b/_sass/base/components/_gallery.scss
@@ -49,5 +49,5 @@
   bottom: 20px;
   position: absolute;
   right: 80px;
-  z-index: 100000;
+  z-index: $z-rooftop;
 }

--- a/_sass/base/components/_search-toggles.scss
+++ b/_sass/base/components/_search-toggles.scss
@@ -110,7 +110,7 @@ $toggle-padding: 15px;
   position: absolute;
   top: 100%;
   width: 200%;
-  z-index: 10000;
+  z-index: $z-third;
 
   .search_category {
     font-weight: $weight-book;

--- a/_sass/base/components/_tooltip.scss
+++ b/_sass/base/components/_tooltip.scss
@@ -40,7 +40,7 @@
   position: absolute;
   text-align: left;
   top: 100%;
-  z-index: 1000;
+  z-index: $z-rooftop;
 
   .tooltip-content,
   .tooltip-arrow {

--- a/search/index.html
+++ b/search/index.html
@@ -118,7 +118,7 @@ permalink: /search/
         </div>
 
         <div class="pagination container show-loaded show-incremental">
-          <!-- <input type="hidden" name="page"> -->
+          <input type="hidden" name="page">
           <ol data-bind="pages">
             Page:
             <li><a class="select-page" data-bind="link">1</a></li>
@@ -137,7 +137,7 @@ permalink: /search/
                 data-bind="under_investigation" aria-hidden="true">
                 <a>
                   <p class="investigation-major" aria-describedby="tip-hcm2">
-                    Under ED Monitoring <i class="tooltip-target fa fa-info-circle"></i>
+                    Under ED Monitoring <i class="fa fa-info-circle"></i>
                   </p>
                 </a>
               </div>


### PR DESCRIPTION
Adds variables for z-index so they're easier to keep track of. Removes stray tooltip-target that was messing up things for the under investigation label tooltip. Addresses #971 .