### PR TITLE
Fixes misplaced div and selector for spacing beneath paragraphs

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -242,10 +242,10 @@
         @include respond-to(small-up) {
           padding-top: 0;
         }
+      }
 
-        p {
-          padding-bottom: 0;
-        }
+      p {
+        padding-bottom: 0;
       }
     }
 

--- a/school/index.html
+++ b/school/index.html
@@ -322,8 +322,6 @@ stylesheets:
                       <p>At some schools where few students borrow federal loans, the typical undergraduate may leave school with $0 in debt.</p>
                     </div>
 
-                  </div>
-
                     <div>
                       <h2
                         aria-describedby="tip-avg-debt">
@@ -349,6 +347,7 @@ stylesheets:
                       </span>
                     </div>
 
+                  </div>
                 </div>
               </div>
             </aria-accordion>


### PR DESCRIPTION
Looks like:

![screenshot 2015-09-08 18 31 29](https://cloud.githubusercontent.com/assets/4827522/9751335/3553a1f4-5658-11e5-9336-9a19284d7805.png)
