### PR TITLE
Fixes missing images in share tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,9 +33,9 @@
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 
   <!-- img -->
-  <meta property="og:img" content="{{ site.baseurl }}/img/hero.jpg">
+  <meta property="og:img" content="{{ site.url }}/img/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="{{ site.baseurl }}/img/hero.jpg">
+  <meta name="twitter:image" content="{{ site.url }}/img/hero.jpg">
 
   <!-- description -->
   <meta property="og:description" content="{{ site.description }}">


### PR DESCRIPTION
Makes meta links to images full url instead of relative. It will show the background image on the homepage.

Addresses #1279.