### PR TITLE
Order US states by name, not abbreviation

### DIFF
--- a/_data/states.csv
+++ b/_data/states.csv
@@ -1,56 +1,56 @@
 abbr,name
-AK,Alaska
 AL,Alabama
-AR,Arkansas
+AK,Alaska
+AS,American Samoa
 AZ,Arizona
+AR,Arkansas
 CA,California
 CO,Colorado
 CT,Connecticut
-DC,District of Columbia
 DE,Delaware
+DC,District of Columbia
 FL,Florida
 GA,Georgia
+GU,Guam
 HI,Hawaii
-IA,Iowa
 ID,Idaho
 IL,Illinois
 IN,Indiana
+IA,Iowa
 KS,Kansas
 KY,Kentucky
 LA,Louisiana
-MA,Massachusetts
-MD,Maryland
 ME,Maine
+MD,Maryland
+MA,Massachusetts
 MI,Michigan
 MN,Minnesota
-MO,Missouri
 MS,Mississippi
+MO,Missouri
 MT,Montana
-NC,North Carolina
-ND,North Dakota
 NE,Nebraska
+NV,Nevada
 NH,New Hampshire
 NJ,New Jersey
 NM,New Mexico
-NV,Nevada
 NY,New York
+NC,North Carolina
+ND,North Dakota
 OH,Ohio
 OK,Oklahoma
 OR,Oregon
 PA,Pennsylvania
+PR,Puerto Rico
 RI,Rhode Island
 SC,South Carolina
 SD,South Dakota
 TN,Tennessee
 TX,Texas
 UT,Utah
-VA,Virginia
-VI,Virgin Islands
 VT,Vermont
+VI,Virgin Islands
+VA,Virginia
 WA,Washington
-WI,Wisconsin
 WV,West Virginia
+WI,Wisconsin
 WY,Wyoming
-PR,Puerto Rico
-GU,Guam
-AS,American Samoa


### PR DESCRIPTION
Discovered by @datametrician

Before:

<img width="567" alt="screen shot 2015-09-13 at 9 46 26 pm" src="https://cloud.githubusercontent.com/assets/44956/9841237/e90bdbcc-5a62-11e5-994e-309f410fc318.png">

HTML:

<img width="278" alt="screen shot 2015-09-13 at 9 28 07 pm" src="https://cloud.githubusercontent.com/assets/44956/9841241/edba24bc-5a62-11e5-8cdb-d301a2a28ec8.png">
