### PR TITLE
Fix dlapiduz's GitHub ID; quotes around milestones

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -29,7 +29,7 @@ team:
 - github: meiqimichelle
 - github: yozlet
 - github: hollyallen
-- github: dlapiduz
+- github: diego-
 milestones: 
 - "June 2015: Kick-off meeting"
 - "August 2015: Private beta launched"

--- a/.about.yml
+++ b/.about.yml
@@ -29,11 +29,11 @@ team:
 - github: meiqimichelle
 - github: yozlet
 - github: hollyallen
-- github: diego-
+- github: dlapiduz
 milestones: 
-- June 2015: Kick-off meeting
-- August 2015: Private beta launched
-- September 2015: Public live launch
+- "June 2015: Kick-off meeting"
+- "August 2015: Private beta launched"
+- "September 2015: Public live launch"
 impact: 3 Million site views since September 2015
 licenses:
   collegescorecard:


### PR DESCRIPTION
`milestones:` takes a list of strings; any string with a colon in it must be quoted, or the YAML parser interprets the string as a key/value pair.

cc: @hollyallen 