### PR TITLE
Increase padding on student population number

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -487,6 +487,7 @@
   .group_inline-left {
     display: inline-block;
     padding-right: 8px;
+    padding-left: 25px;
   }
 
   .group_inline-right {


### PR DESCRIPTION
Not enough padding causes large student body numbers to be squished.

Before
------------
![student_body_num_before](https://cloud.githubusercontent.com/assets/954858/11804327/cd719e86-a2b7-11e5-89ee-e3472a4f61bc.png)


After
--------
![student_body_num_after](https://cloud.githubusercontent.com/assets/954858/11804331/d46d3dda-a2b7-11e5-94dc-760901d30585.png)
