### PR TITLE
Increase contrast for the school page sidebar.

### DIFF
--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -28,6 +28,7 @@
   margin-top: $base-padding;
   padding-left: $base-padding;
   padding-right: $base-padding;
+  background-color: $white;
 
   h2 {
     padding-bottom: $base-padding;

--- a/_sass/base/blocks/_school.scss
+++ b/_sass/base/blocks/_school.scss
@@ -26,9 +26,11 @@
 
 .school-right {
   margin-top: $base-padding;
+  padding-top: $base-padding;
   padding-left: $base-padding;
   padding-right: $base-padding;
   background-color: $white;
+  border-radius: 0.4em;
 
   h2 {
     padding-bottom: $base-padding;
@@ -61,8 +63,6 @@
   @include respond-to(medium-up) {
     @include span-columns(3);
     @include omega();
-    padding-left: 0;
-    padding-right: 0;
     margin-top: $base-padding;
 
     h2 {


### PR DESCRIPTION
Fixes #1419.

I mucked around with the CSS a little more than I'd like. On my Macbook Air, the previous CSS eliminated the left/right padding, which didn't look good. The downside to adding the padding back is that on medium screensizes the text within the button breaks onto two lines easily.

I'd like some feedback on whether or not this padding change is necessary. Here's how it looks right now on my Macbook Air, browser full-paged:
![screen shot 2016-01-16 at 10 59 46 pm](https://cloud.githubusercontent.com/assets/2475615/12376368/fc2430b6-bca4-11e5-9d50-df5907748caa.png)
