### PR TITLE
CI test fixes

### DIFF
--- a/test/a11y.js
+++ b/test/a11y.js
@@ -33,7 +33,7 @@ async.mapSeries(URLS, function(url, done) {
     }
 
     // filter out "invalid" (ignoreable) results
-    results = results.filter(isValidResult);
+    results = results ? results.filter(isValidResult) : [];
 
     reporter.results(results, url);
 

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -38,7 +38,7 @@ pid=$!
 wget --retry-connrefused --waitretry=1 -T 5 -t 30 -qO- http://localhost:4000 > /dev/null || exit 1
 
 # run the browser tests
-./node_modules/.bin/wdio test/wdio.quick.js || (kill -9 $pid; exit 1)
+./node_modules/.bin/wdio test/wdio.ci.js || (kill -9 $pid; exit 1)
 
 # run the accessibility tests
 npm run test-a11y || (kill -9 $pid; exit 1)

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -1,10 +1,14 @@
+#!/bin/bash
+
 # test against different APIs based on the branch being built
 if [ $CIRCLE_BRANCH ]; then
-    if [ $branch = 'master' ]; then
+    branch=$CIRCLE_BRANCH
+
+    if [ $branch == 'master' ]; then
 
         echo "[using the default (production) API]"
 
-    elif [ $branch = 'staging' ]; then
+    elif [ $branch == 'staging' ]; then
 
         echo "[using the staging API]"
         API_BASE_URL=https://api.data.gov/TEST/ed/staging/v1/
@@ -34,7 +38,9 @@ pid=$!
 wget --retry-connrefused --waitretry=1 -T 5 -t 30 -qO- http://localhost:4000 > /dev/null || exit 1
 
 # run the browser tests
-./node_modules/.bin/wdio test/wdio.ci.js || (kill -9 $pid; exit 1)
+./node_modules/.bin/wdio test/wdio.quick.js || (kill -9 $pid; exit 1)
 
 # run the accessibility tests
-npm run test-a11y
+npm run test-a11y || (kill -9 $pid; exit 1)
+
+kill -9 $pid || exit 0


### PR DESCRIPTION
This PR fixes a couple of issues with the CI test suite:

1. The a11y test runner was assuming that it would get results back, so it would fail if it didn't (which is what happens when there are no warnings or errors).
1. The `test/ci.sh` script now runs with bash, properly sets the `branch` variable for comparison, uses `==` for equality tests, and _might_ even resolve #1423.