### PR TITLE
Improved JavaScript docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,12 @@ the source files.
 ## Front End Development
 
 ### Stylesheets
-- We use [Sass] to generate our CSS.
+- We use [Sass] to generate our CSS. Jekyll handles this automatically.
 - [Montserrat] is our primary font, courtesy of [Google Fonts](https://www.google.com/fonts/).
 
 ### JavaScript
-- We use [npm](https://www.npmjs.com/) to manage our JavaScript dependencies.
-  See the [package.json](https://github.com/18F/college-choice/blob/master/package.json)
-  for the list of libraries and tools we use.
-- We bundle our JavaScript with [browserify](http://browserify.org/).
-- We use [D3] for client-side data management, DOM manipulation, and event handling.
+See the [JavaScript docs](js/#readme) for more information on our scripting tools and
+workflow.
 
 ### Accessibility
 - We adhere to [Web Content Accessibility Guidelines 2.0](https://www.w3.org/WAI/WCAG20/quickref/),
@@ -69,18 +66,15 @@ the source files.
 
 
 ## Content
-
-For the content on the College Scorecard, we are following the [18F Content
-Guide](https://pages.18f.gov/content-guide/).
-
+For the content on the College Scorecard, we are following the [18F Content Guide].
 
 
 ## Running the API Locally
 To set up the API (as a developer), follow the [Open Data Maker installation
 instructions](https://github.com/18F/open-data-maker/blob/dev/INSTALL.md) then:
 
-1. download the [full data set](https://s3.amazonaws.com/ed-college-choice-public/CollegeScorecard_Raw_Data.zip)
-   into open-data-maker directory and rename the folder as "real-data"
+1. download the [full data set] into open-data-maker directory and rename the
+   folder as "real-data"
 
 1. set `DATA_PATH` environment variable.  On the command line:
 
@@ -128,19 +122,23 @@ instructions](https://github.com/18F/open-data-maker/blob/dev/INSTALL.md) then:
 
 ## System Architecture
 This repository drives the "front end" of the College Scorecard application and
-is hosted on [Federalist](https://github.com/18F/federalist). The back end is
-an instance of the [Open Data Maker](https://github.com/18F/open-data-maker/).
+is hosted on [Federalist]. The back end is an instance of the [Open Data Maker].
 Here's how the different parts work together in our production environment:
 
 ![system architecture](docs/architecture-diagram.png)
 
 
 ## Content
-For the content on the College Scorecard, we are following the [18F Content Guide](https://pages.18f.gov/content-guide/).
+For the content on the College Scorecard, we are following the [18F Content Guide].
 
-
-[Montserrat]: https://www.google.com/fonts/specimen/Montserrat
-[Jekyll]: http://jekyllrb.com/
-[Sass]: http://sass-lang.com/
+[18F Content Guide]: https://pages.18f.gov/content-guide/
 [D3]: http://d3js.org/
+[Federalist]: https://github.com/18F/federalist
+[full data set]: https://s3.amazonaws.com/ed-college-choice-public/CollegeScorecard_Raw_Data.zip
+[Open Data Maker]: https://github.com/18F/open-data-maker/
+[Jekyll]: http://jekyllrb.com/
+[Montserrat]: https://www.google.com/fonts/specimen/Montserrat
+[npm]: https://www.npmjs.com/
 [Ruby]: https://www.ruby-lang.org/
+[Sass]: http://sass-lang.com/
+[UglifyJS]: https://github.com/mishoo/UglifyJS

--- a/README.md
+++ b/README.md
@@ -132,13 +132,10 @@ Here's how the different parts work together in our production environment:
 For the content on the College Scorecard, we are following the [18F Content Guide].
 
 [18F Content Guide]: https://pages.18f.gov/content-guide/
-[D3]: http://d3js.org/
 [Federalist]: https://github.com/18F/federalist
 [full data set]: https://s3.amazonaws.com/ed-college-choice-public/CollegeScorecard_Raw_Data.zip
 [Open Data Maker]: https://github.com/18F/open-data-maker/
 [Jekyll]: http://jekyllrb.com/
 [Montserrat]: https://www.google.com/fonts/specimen/Montserrat
-[npm]: https://www.npmjs.com/
 [Ruby]: https://www.ruby-lang.org/
 [Sass]: http://sass-lang.com/
-[UglifyJS]: https://github.com/mishoo/UglifyJS

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,66 @@
+# JavaScript
+
+## Dependencies
+We use [npm] to manage our JavaScript dependencies. To install them, run
+
+```
+npm install --dev
+```
+
+from the project root directory.
+
+## Libraries
+- We use a custom build of [D3] for client-side data management, DOM manipulation, and
+  event handling. The custom build is generated with [Rollup], and keeps our bundles
+  nice and slim.
+- Client-side templating is currently handled by a pre-release version of [tagalong],
+  which will eventually be upgraded. Tagalong allows us to keep all of the markup for
+  dynamic elements in the HTML documents where they're used, rather than in external
+  templates, and is more performant than brute-force `innerHTML` manipulation.
+
+## Build Process
+We bundle our JavaScript with [browserify](http://browserify.org/). The bundling process
+combines all of the site's dependencies and page-specific code into a single script,
+which is then minified with [UglifyJS] to make it smaller and faster.
+
+To build the JavaScript, you'll need to first install all of the [npm] dependencies with
+
+```
+npm install --dev
+```
+
+(Note: newer versions of Node may warn about the `--dev` option being deprecated; you can
+safely ignore those.) Once the dependencies are finished installing, you can build the
+bundle with:
+
+```
+npm run build
+```
+  
+You can also run `npm run watch` to have the JavaScript automatically bundled whenever the
+source files change.
+
+### Dealing with Merge Conflicts
+While keeping minified JavaScript in git simplifies our deployment, it also inevitably
+leads to merge conflicts when multiple branches modify any of the source scripts. If you
+encounter a merge conflict, follow these steps:
+
+1. Fix any merge conflicts in the source JavaScript
+1. `npm run build` to rebuild the bundle
+1. [Run the tests](../test/#readme) to ensure that the build works as expected
+1. `git add js/picc.js*` to add the newly bundle script to the merge commit
+1. `git commit` to complete the merge
+
+We hope to address [this particular issue](https://github.com/18F/college-choice/issues/1455)
+soon.
+
+## Testing
+We have both a nascent unit test suite and a more comprehensive suite of browser tests to
+help us ensure that changes to the JavaScript don't introduce new bugs. See the
+[testing docs](../test/#readme) for more information on running and updating the tests.
+
+[D3]: http://d3js.org/
+[npm]: https://www.npmjs.com/
+[Rollup]: https://github.com/rollup/rollup
+[tagalong]: http://shawnbot.github.io/tagalong/
+[UglifyJS]: https://github.com/mishoo/UglifyJS


### PR DESCRIPTION
This addresses #1004 and adds specific documentation for how we manage dependencies, build the browser bundle, and handle merge conflicts. You can see the changes to the project README [here](https://github.com/18F/college-choice/tree/js-docs#javascript), which now just link to the [new JS docs](https://github.com/18F/college-choice/tree/js-docs/js#readme).