### PR TITLE
Fix CI false positive

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,9 @@ test:
     - ./test/server.sh:
         background: true
 
+    # wait for the http server to start
+    - wget --retry-connrefused --waitretry=1 -T 5 -t 30 \ -qO- http://localhost:4000 > /dev/null
+
     # run the browser tests
     - npm run test-ci
 

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
     # build the site and start the server (this exits when the server is
     # available at localhost:4000)
     - ./test/server.sh:
-      background: true
+        background: true
 
     # run the browser tests
     - npm run test-ci

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
         background: true
 
     # wait for the http server to start
-    - wget --retry-connrefused --waitretry=1 -T 5 -t 30 \ -qO- http://localhost:4000 > /dev/null
+    - wget --retry-connrefused --waitretry=1 -T 5 -t 30 -qO- http://localhost:4000 > /dev/null
 
     # run the browser tests
     - npm run test-ci

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,8 @@ test:
 
     # build the site and start the server (this exits when the server is
     # available at localhost:4000)
-    - ./test/server.sh
+    - ./test/server.sh:
+      background: true
 
     # run the browser tests
     - npm run test-ci

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,15 @@ test:
     # <https://github.com/webdriverio/webdriverio/issues/926>
     - ln -s /tmp
 
+    # build the site and start the server (this exits when the server is
+    # available at localhost:4000)
+    - ./test/server.sh
+
     # run the browser tests
-    - ./test/ci.sh
+    - npm run test-ci
+
+    # run the accessibility tests
+    - npm run test-a11y
+
   post:
     - killall --wait sc  # wait for Sauce Connect to close the tunnel

--- a/circle.yml
+++ b/circle.yml
@@ -43,4 +43,5 @@ test:
     - npm run test-a11y
 
   post:
-    - killall --wait sc  # wait for Sauce Connect to close the tunnel
+    # wait for Sauce Connect to close the tunnel
+    - killall --wait sc

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "browserify": "^12.0.1",
     "extend": "^3.0.0",
-    "http-server": "^0.8.5",
     "jshint": "^2.8.0",
     "minifyify": "^7.1.0",
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "wdio test/wdio.conf.js",
     "test-quick": "wdio test/wdio.quick.js",
     "test-sauce": "wdio test/wdio.sauce.js",
-    "test-ci": "./test/ci.sh"
+    "test-ci": "wdio test/wdio.ci.js"
   },
   "dependencies": {
     "aight": "^2.1.1",

--- a/test/a11y.js
+++ b/test/a11y.js
@@ -10,9 +10,10 @@ const test = pa11y(config);
 const BASEURL = 'http://localhost:4000';
 
 const URLS = [
-  BASEURL + '/school/?226152-Texas-A-M-International-University',
-  BASEURL + '/search/?state=CA',
   BASEURL + '/',
+  BASEURL + '/search/?state=CA',
+  BASEURL + '/school/?226152-Texas-A-M-International-University',
+  BASEURL + '/data/',
 ];
 
 const IGNORE_RESULTS = [

--- a/test/a11y.js
+++ b/test/a11y.js
@@ -13,7 +13,7 @@ const URLS = [
   BASEURL + '/',
   BASEURL + '/search/?state=CA',
   BASEURL + '/school/?226152-Texas-A-M-International-University',
-  BASEURL + '/data/',
+  // BASEURL + '/data/',
 ];
 
 const IGNORE_RESULTS = [

--- a/test/a11y.js
+++ b/test/a11y.js
@@ -30,6 +30,7 @@ async.mapSeries(URLS, function(url, done) {
 
     if (error) {
       reporter.error(error.stack);
+      return done(error.stack);
     }
 
     // filter out "invalid" (ignoreable) results
@@ -45,21 +46,23 @@ async.mapSeries(URLS, function(url, done) {
     done(null, results);
   });
 }, function(error, runs) {
-  if (failed) {
-    var count = 0;
-    var failing = runs.map(function(results) {
-      var failing = results.filter(isFailingResult);
-      count += failing.length;
-      return failing;
-    })
-    .filter(function(failing) {
-      return failing.length;
-    });
+  if (error || failed) {
+    if (failed) {
+      var count = 0;
+      var failing = runs.map(function(results) {
+        var failing = results.filter(isFailingResult);
+        count += failing.length;
+        return failing;
+      })
+      .filter(function(failing) {
+        return failing.length;
+      });
 
-    reporter.error([
-      pluralize(count, 'failure'),
-      'on', pluralize(failing.length, 'page')
-    ].join(' '));
+      reporter.error([
+        pluralize(count, 'failure'),
+        'on', pluralize(failing.length, 'page')
+      ].join(' '));
+    }
     process.exit(2);
   }
 });

--- a/test/server.sh
+++ b/test/server.sh
@@ -32,15 +32,7 @@ bundle exec jekyll build
 
 # serve it up statically, in the background
 ./node_modules/.bin/http-server -p 4000 _site &
-pid=$!
 
 # wait for the http server to start
-wget --retry-connrefused --waitretry=1 -T 5 -t 30 -qO- http://localhost:4000 > /dev/null || exit 1
-
-# run the browser tests
-./node_modules/.bin/wdio test/wdio.ci.js || (kill -9 $pid; exit 1)
-
-# run the accessibility tests
-npm run test-a11y || (kill -9 $pid; exit 1)
-
-kill -9 $pid || exit 0
+wget --retry-connrefused --waitretry=1 -T 5 -t 30 \
+    -qO- http://localhost:4000 > /dev/null || exit 1

--- a/test/server.sh
+++ b/test/server.sh
@@ -28,11 +28,4 @@ if [ $API_BASE_URL ]; then
 fi
 
 # build the site
-bundle exec jekyll build
-
-# serve it up statically, in the background
-./node_modules/.bin/http-server -p 4000 _site &
-
-# wait for the http server to start
-wget --retry-connrefused --waitretry=1 -T 5 -t 30 \
-    -qO- http://localhost:4000 > /dev/null || exit 1
+bundle exec jekyll serve

--- a/test/spec/schoolpage.js
+++ b/test/spec/schoolpage.js
@@ -3,13 +3,10 @@
 
 var assert = require('assert');
 
-//var pageTimeout = 800;
-
 var loadSchoolUrl = function(school) {
   return browser
     .url('/school/?' + school)
-    .waitForVisible('.show-loading', 5000, true);
-//    .pause(pageTimeout);
+    .waitForVisible('.show-loaded');
 };
 
 var getBanners = function() {


### PR DESCRIPTION
This addresses #1471 by reorganizing the CI test runner. Previously, the `test/ci.sh` script did all of these things in serial:

1. Figure out which API base URL to use based on `$CIRCLE_BRANCH`.
1. Build the site with `jekyll build`.
1. Serve it with the Node-based `http-server` (which was _slightly_ faster than Jekyll) in the background (with `&`).
1. Wait for the server to start up with `wget --waitretry=1`.
1. Run the browser tests, and kill the server then `exit 1` if they fail.
1. Run the a11y tests, and kill the server then `exit 1` if they fail.

This was super brittle and difficult to debug, so I refactored it into four steps that run as separate commands in the `circle.yml`:

1. The API base URL detection and server startup happen in `test/server.sh`, build and serve with Jekyll, and fork in the background using Circle's `background: true` flag. No need for `http-server` anymore.
1. Wait for the server to start with `wget`.
1. Run the browser tests.
1. Run the a11y tests.

Circle doesn't short-circuit these commands, so we can see the a11y results even if the browser tests fail.  Circle also tells us how long each command took, so we can see now how long each specific step takes. (For instance, in [this build](https://circleci.com/gh/18F/college-choice/274) it took 20+ seconds waiting for Sauce Connect to open a tunnel.) This reorganization also gets us closer to being able to parallelize our builds (#1468), and will make it easier to factor our the server step entirely if we decide to follow through with #1474.

This PR should also address some errant CI timeouts in af348b0 by using the globally configured wait time (20 seconds, rather than 5) for all school tests.

This branch has the accordion fixes in #1465 merged in already, so we should merge that PR first.