### PR TITLE
Add meta description

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,6 +48,7 @@
   <meta name="twitter:image" content="{{ canonical_base_url }}/img/hero-small.jpg">
 
   <!-- description -->
+  <meta name="description" content="{{ site.description }}">
   <meta property="og:description" content="{{ site.description }}">
   <meta name="twitter:description" content="{{ site.description }}">
 


### PR DESCRIPTION
This should wrap up #1291 by adding a plain old `description` meta tag in addition to the `og:description`.