### PR TITLE
Tell Hound CI to ignore minified JS

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 javascript:
   config_file: .jshintrc
+  ignore_file: .jshintignore

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+js/picc.js


### PR DESCRIPTION
This adds a `.jshintignore` file that ignores `js/picc.js` (which is minified and essentially un-lintable) and tells @houndci to use it.