### PR TITLE
Use PhantomJS 2.0 on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,15 @@
 machine:
   node:
     version: 4.0
+
+# this is Circle CI's suggested way of installing PhantomJS 2.0
+dependencies:
+  pre:
+    - sudo apt-get update; sudo apt-get install libicu52
+    - curl --output /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic https://s3.amazonaws.com/circle-support-bucket/phantomjs/phantomjs-2.0.1-linux-x86_64-dynamic
+    - chmod a+x /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic
+    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic /usr/local/bin/phantomjs
+
 test:
   override:
     # create directories for xunit reports


### PR DESCRIPTION
This is a possible fix for #1502 that upgrades to PhantomJS 2.0, which _might_ work around the 1.x release's TLS issues and allow it to load the production URL. (Tip o' the hat to @konklone for [that suggestion](https://github.com/18F/college-choice/issues/1502#issuecomment-190554993)).

We actually won't know if this works until we merge to master, but the tests ran successfully on this branch so I'm going to merge up and tag a new patch release before we release to staging.