### PR TITLE
Update data download base URL

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -2,7 +2,7 @@
 title: College Scorecard Data
 layout: default-data
 permalink: /data/
-data_base_url: https://download.collegescorecard.ed.gov
+data_base_url: https://collegescorecard.ed.gov/downloads
 scripts:
   - vendor/flickity.pkgd.js
 stylesheets:

--- a/data/index.html
+++ b/data/index.html
@@ -120,10 +120,10 @@ stylesheets:
         current data for each element.</p>
 
       <ul class="data-download-list">
-        <li><a href="{{ page.data_base_url }}/Most+Recent+Cohorts+Scorecard+Elements.csv">Scorecard data</a> 4.6 MB CSV</li>
-        <li><a href="{{ page.data_base_url }}/Most+Recent+Cohorts+All+Data+Elements.csv">Most recent data</a> 124 MB CSV</li>
-        <li><a href="{{ page.data_base_url }}/Most+Recent+Cohorts+NSLDS+Elements.csv">What's new from NSLDS</a> 104.4 MB CSV</li>
-        <li><a href="{{ page.data_base_url }}/Most+Recent+Cohorts+Treasury+Elements.csv">Post-school earnings</a> 7.4 MB CSV</li>
+        <li><a href="{{ page.data_base_url }}/Most-Recent-Cohorts-Scorecard-Elements.csv">Scorecard data</a> 4.8 MB CSV</li>
+        <li><a href="{{ page.data_base_url }}/Most-Recent-Cohorts-All-Data-Elements.csv">Most recent data</a> 155 MB CSV</li>
+        <li><a href="{{ page.data_base_url }}/Most-Recent-Cohorts-NSLDS-Elements.csv">What's new from NSLDS</a> 139 MB CSV</li>
+        <li><a href="{{ page.data_base_url }}/Most-Recent-Cohorts-Treasury-Elements.csv">Post-school earnings</a> 7.8 MB CSV</li>
       </ul>
 
     </div>


### PR DESCRIPTION
[:sunglasses: preview on Federalist](https://federalist.18f.gov/preview/18F/college-choice/download-baseurl/data/)

This switches the data download base URL from:

```
https://download.collegescorecard.ed.gov
```

to:

```
https://collegescorecard.ed.gov/downloads
```