### PR TITLE
Fix keyboard enter press on search forms

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ baseurl:
 url: https://collegescorecard.ed.gov
 
 # app version number
-version: v1.7.6
+version: v1.7.7
 
 # Build settings
 markdown: kramdown

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -6,7 +6,7 @@
     <aria-accordion id="school-degree" class="container">
 
       <h1 class="search_category">
-        <button aria-expanded="false" aria-controls="major-content">
+        <button type="button" aria-expanded="false" aria-controls="major-content">
           Programs/Degrees
         </button>
       </h1>
@@ -43,7 +43,7 @@
     <aria-accordion id="school-location" class="container">
 
       <h1 class="search_category">
-        <button aria-expanded="false" aria-controls="location-content">
+        <button type="button" aria-expanded="false" aria-controls="location-content">
           Location
         </button>
       </h1>
@@ -66,10 +66,10 @@
               </select>
             </div>
             <div class="u-group_inline u-group_inline-right u-nowrap">
-              <button class="button button-add">
+              <button type="button" class="button button-add">
                 Add<br>State
               </button>
-              <button class="button button-remove" title="Remove State">
+              <button type="button" class="button button-remove" title="Remove State">
                 <i class="fa fa-times-circle"></i>
               </button>
             </div>
@@ -93,10 +93,10 @@
               </select>
             </div>
             <div class="u-group_inline u-group_inline-right u-nowrap">
-              <button class="button button-add">
+              <button type="button" class="button button-add">
                 Add<br>Region
               </button>
-              <button class="button button-remove" title="Remove Region">
+              <button type="button" class="button button-remove" title="Remove Region">
                 &times;
               </button>
             </div>
@@ -137,7 +137,7 @@
     <aria-accordion id="school-size" class="container">
 
       <h1 class="search_category">
-        <button aria-expanded="false" aria-controls="size-content">
+        <button type="button" aria-expanded="false" aria-controls="size-content">
           Size
         </button>
       </h1>
@@ -185,7 +185,7 @@
     <aria-accordion id="school-name" class="container">
 
       <h1 class="search_category">
-        <button aria-expanded="false" aria-controls="name-content">
+        <button type="button" aria-expanded="false" aria-controls="name-content">
           Name
         </button>
       </h1>
@@ -195,7 +195,7 @@
         <input id="name-school" name="name" type="text" placeholder="e.g., USA University" {{ common_input_attributes }}>
       </div>
 
-      <input type="submit" value="Submit" class="sr-only" tabindex="-1">
+      <input type="submit" value="Submit" class="sr-only">
 
     </aria-accordion>
 
@@ -206,7 +206,7 @@
 
     <aria-accordion class="container">
       <h1 class="search_category">
-        <button aria-expanded="false" aria-controls="type-content">
+        <button type="button" aria-expanded="false" aria-controls="type-content">
           Advanced Search
         </button>
       </h1>
@@ -276,7 +276,7 @@
           <legend>Advanced Search</legend>
 
           <div class="advanced_search-title">
-            <button aria-expanded="false" aria-controls="advanced-content" class="button link-more advanced_search-control">
+            <button type="button" aria-expanded="false" aria-controls="advanced-content" class="button link-more advanced_search-control">
               Advanced Search <i class="fa fa-plus"></i>
             </button>
           </div>
@@ -291,7 +291,7 @@
 
     </fieldset> END section for future advanced search features -->
 
-    <button id="search-submit" class="button button-primary search-button">
+    <button type="submit" id="search-submit" class="button button-primary search-button">
       Find Schools
     </button>
 

--- a/search/index.html
+++ b/search/index.html
@@ -16,7 +16,7 @@ permalink: /search/
 
         <div class="toggle-control">
           <h1 class="search_category">
-            <button aria-expanded="false" aria-controls="filter-content">
+            <button type="button" aria-expanded="false" aria-controls="filter-content">
               <i class="fa fa-filter"></i>Filter Results<i class="fa fa-chevron-down"></i>
             </button>
           </h1>
@@ -38,7 +38,7 @@ permalink: /search/
         <div class="toggle-control">
           <legend>Edit Search</legend>
           <h1 class="search_category">
-            <button aria-expanded="false" aria-controls="search-content">
+            <button type="button" aria-expanded="false" aria-controls="search-content">
               <i class="fa fa-search"></i>Edit Search<i class="fa fa-chevron-down"></i>
             </button>
           </h1>


### PR DESCRIPTION
[:sunglasses: preview on Federalist](https://federalist.18f.gov/preview/18F/college-choice/fix-keyboard-submit/)

This is a fix for #1518.

Previously, pressing <kbd>enter</kbd> in the search forms triggered a form submission, but I broke this in the process of bringing better keyboard accessibility to our accordions in #54. The fix was to add `type="button"` to all of our accordion button elements, which prevents browsers from treating them as submit buttons and short-circuiting the form submission. [MDN has the skinny](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type).